### PR TITLE
fix: apply gradient design system to MainActivity (#4)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,8 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
@@ -49,6 +51,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     testImplementation(libs.junit)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.testingapplictionandriod.ui.home.HomeScreen
+import com.example.testingapplictionandriod.ui.home.HomeViewModel
 import com.example.testingapplictionandriod.ui.theme.TestingapplictionandriodTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +17,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TestingapplictionandriodTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                val viewModel: HomeViewModel = viewModel()
+                val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+                HomeScreen(uiState = uiState)
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TestingapplictionandriodTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
@@ -1,0 +1,46 @@
+package com.example.testingapplictionandriod.ui.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.R
+import com.example.testingapplictionandriod.ui.theme.TestingapplictionandriodTheme
+
+@Composable
+fun HomeScreen(uiState: HomeUiState) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.home_greeting),
+            color = Color.White,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeScreenPreview() {
+    TestingapplictionandriodTheme {
+        HomeScreen(uiState = HomeUiState())
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeUiState.kt
@@ -1,0 +1,5 @@
+package com.example.testingapplictionandriod.ui.home
+
+data class HomeUiState(
+    val isLoading: Boolean = false
+)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeViewModel.kt
@@ -1,0 +1,11 @@
+package com.example.testingapplictionandriod.ui.home
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class HomeViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">testingapplictionandriod</string>
+    <string name="home_greeting">Hello Android!</string>
 </resources>

--- a/app/src/test/java/com/example/testingapplictionandriod/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/testingapplictionandriod/ui/home/HomeViewModelTest.kt
@@ -1,0 +1,46 @@
+package com.example.testingapplictionandriod.ui.home
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has isLoading false`() = runTest {
+        val viewModel = HomeViewModel()
+
+        val state = viewModel.uiState.value
+
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `uiState emits initial HomeUiState`() = runTest {
+        val viewModel = HomeViewModel()
+
+        val state = viewModel.uiState.value
+
+        assert(state == HomeUiState())
+    }
+}


### PR DESCRIPTION
## Summary
- Replaced flat `Scaffold` + black text with a `Box` using `Brush.verticalGradient(Color(0xFF0F0C29) → Color(0xFF302B63) → Color(0xFF24243E))`
- Text colour updated to `Color.White` per CLAUDE.md rules
- Introduced MVVM structure: `HomeScreen.kt`, `HomeViewModel.kt`, `HomeUiState.kt`
- Moved greeting string to `strings.xml` — no hardcoded strings remain
- Added `HomeViewModelTest.kt` (happy path + isLoading=false cases)

## Test plan
- [x] `./gradlew assembleDebug` — passes
- [x] `./gradlew test` — passes
- [ ] Visual check: dark gradient background + white text on device/emulator

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)