### PR TITLE
feat: change background to red gradient (#12)

### DIFF
--- a/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
@@ -19,7 +19,7 @@ fun HomeScreen(uiState: HomeUiState) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
+                    listOf(Color(0xFFEF4444), Color(0xFFDC2626))
                 )
             ),
         contentAlignment = Alignment.Center


### PR DESCRIPTION
## Summary

- Changed the full-screen background in `HomeScreen` from the dark purple gradient to a red gradient using the design system's Error colour tokens (`Color(0xFFEF4444)` → `Color(0xFFDC2626)`)
- Flat solid colours remain forbidden per `CLAUDE.md`; the gradient rule is preserved

## Changed files

- `app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt`

## Testing notes

- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL, all unit tests pass
- Visual: full-screen red vertical gradient rendered at runtime

Closes #12