### PR TITLE
feat: change background color to blue gradient (#22)

### DIFF
--- a/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt
@@ -21,7 +21,7 @@ fun HomeScreen(uiState: HomeUiState) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(Color(0xFFEF4444), Color(0xFFDC2626))
+                    listOf(Color(0xFF06B6D4), Color(0xFF3B82F6))
                 )
             ),
         contentAlignment = Alignment.Center


### PR DESCRIPTION
## Summary

- Changes the `HomeScreen` background from a red gradient to a blue gradient
- Uses the Accent color tokens from the design system: `Color(0xFF06B6D4)` → `Color(0xFF3B82F6)`
- Follows CLAUDE.md mandatory `Brush.verticalGradient` requirement (no flat colors)

## Changed Files

- `app/src/main/java/com/example/testingapplictionandriod/ui/home/HomeScreen.kt` — updated background gradient colors from red (`0xFFEF4444`, `0xFFDC2626`) to blue (`0xFF06B6D4`, `0xFF3B82F6`)

## Testing Notes

- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL, all unit tests pass
- No ViewModel or business logic changed, so no new tests required

Closes #22