### PR TITLE
feat: redesign Calendar app UI matching reference design (#27)

### DIFF
--- a/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
@@ -24,8 +24,8 @@ class MainActivity : ComponentActivity() {
                     onNextMonth = viewModel::onNextMonth,
                     onGoToToday = viewModel::onGoToToday,
                     onDaySelected = viewModel::onDaySelected,
-                    onShowAddEvent = viewModel::onShowAddEvent,
-                    onDismissAddEvent = viewModel::onDismissAddEvent,
+                    onShowCreateEvent = viewModel::onShowCreateEvent,
+                    onDismissCreateEvent = viewModel::onDismissCreateEvent,
                     onNewEventTitleChange = viewModel::onNewEventTitleChange,
                     onNewEventDescriptionChange = viewModel::onNewEventDescriptionChange,
                     onNewEventTypeChange = viewModel::onNewEventTypeChange,
@@ -34,7 +34,9 @@ class MainActivity : ComponentActivity() {
                     onNewEventEndHourChange = viewModel::onNewEventEndHourChange,
                     onNewEventEndMinuteChange = viewModel::onNewEventEndMinuteChange,
                     onAddEvent = viewModel::onAddEvent,
-                    onDeleteEvent = viewModel::onDeleteEvent
+                    onDeleteEvent = viewModel::onDeleteEvent,
+                    onShowEventDetail = viewModel::onShowEventDetail,
+                    onBackToCalendar = viewModel::onBackToCalendar
                 )
             }
         }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -192,7 +192,7 @@ private fun CalendarTopBar(
     onGoToToday: () -> Unit
 ) {
     val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, 1) }
-    val monthName = SimpleDateFormat("MMMM", Locale.getDefault()).format(cal.time)
+    val monthName = SimpleDateFormat(stringResource(R.string.date_format_month_only), Locale.getDefault()).format(cal.time)
 
     Row(
         modifier = Modifier
@@ -267,7 +267,7 @@ private fun WeekdayHeaders() {
                 text = label,
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
-                color = Color.White.copy(alpha = 0.50f),
+                color = Color.White.copy(alpha = 0.87f),
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
                 letterSpacing = 1.sp
@@ -398,8 +398,8 @@ private fun CalendarDayCell(
                         if (dayEvents.size > 3) {
                             Text(
                                 text = stringResource(R.string.events_overflow_count, dayEvents.size - 3),
-                                color = if (isSelected || isToday) Color.White.copy(alpha = 0.80f)
-                                        else Color.White.copy(alpha = 0.50f),
+                                color = if (isSelected || isToday) Color.White
+                                        else Color.White.copy(alpha = 0.87f),
                                 fontSize = 8.sp,
                                 fontWeight = FontWeight.Bold
                             )
@@ -527,7 +527,7 @@ private fun PanelEmptyState(message: String) {
     ) {
         Text(
             text = message,
-            color = Color.White.copy(alpha = 0.55f),
+            color = Color.White.copy(alpha = 0.87f),
             fontSize = 14.sp,
             textAlign = TextAlign.Center
         )
@@ -584,14 +584,14 @@ private fun EventPanelCard(
                     event.endHour.padded(),
                     event.endMinute.padded()
                 ),
-                color = Color.White.copy(alpha = 0.58f),
+                color = Color.White.copy(alpha = 0.87f),
                 fontSize = 12.sp
             )
             if (event.description.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = event.description,
-                    color = Color.White.copy(alpha = 0.50f),
+                    color = Color.White.copy(alpha = 0.87f),
                     fontSize = 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -350,7 +350,9 @@ private fun CalendarDayCell(
                                 RoundedCornerShape(14.dp)
                             )
                             else -> Modifier.background(
-                                Color.White.copy(alpha = 0.04f),
+                                Brush.linearGradient(
+                                    listOf(Color(0xFF6366F1).copy(alpha = 0.04f), Color(0xFF8B5CF6).copy(alpha = 0.04f))
+                                ),
                                 RoundedCornerShape(14.dp)
                             )
                         }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -210,7 +210,7 @@ private fun CalendarTopBar(
             )
             Text(
                 text = year.toString(),
-                color = Color.White.copy(alpha = 0.55f),
+                color = Color.White.copy(alpha = 0.87f),
                 fontWeight = FontWeight.Medium,
                 fontSize = 14.sp
             )
@@ -621,7 +621,7 @@ private fun EventPanelCard(
             Icon(
                 imageVector = Icons.Filled.Delete,
                 contentDescription = stringResource(R.string.cd_delete_event),
-                tint = Color.White.copy(alpha = 0.50f),
+                tint = Color.White,
                 modifier = Modifier.size(18.dp)
             )
         }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -461,7 +461,7 @@ private fun EventsPanel(
             Text(
                 text = if (selectedDay != null) {
                     val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, selectedDay) }
-                    SimpleDateFormat("EEEE, MMM d", Locale.getDefault()).format(cal.time)
+                    SimpleDateFormat(stringResource(R.string.date_format_day_month), Locale.getDefault()).format(cal.time)
                 } else {
                     stringResource(R.string.events_title_no_selection)
                 },
@@ -473,7 +473,7 @@ private fun EventsPanel(
             if (selectedDay != null && selectedEvents.isNotEmpty()) {
                 Text(
                     text = pluralStringResource(R.plurals.events_count, selectedEvents.size, selectedEvents.size),
-                    color = Color.White.copy(alpha = 0.55f),
+                    color = Color.White.copy(alpha = 0.87f),
                     fontSize = 13.sp
                 )
             }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -5,9 +5,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,23 +16,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,7 +40,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import com.example.testingapplictionandriod.R
 import com.example.testingapplictionandriod.domain.model.CalendarEvent
 import com.example.testingapplictionandriod.domain.model.EventType
@@ -60,8 +53,8 @@ fun CalendarScreen(
     onNextMonth: () -> Unit,
     onGoToToday: () -> Unit,
     onDaySelected: (Int) -> Unit,
-    onShowAddEvent: () -> Unit,
-    onDismissAddEvent: () -> Unit,
+    onShowCreateEvent: () -> Unit,
+    onDismissCreateEvent: () -> Unit,
     onNewEventTitleChange: (String) -> Unit,
     onNewEventDescriptionChange: (String) -> Unit,
     onNewEventTypeChange: (EventType) -> Unit,
@@ -70,6 +63,59 @@ fun CalendarScreen(
     onNewEventEndHourChange: (Int) -> Unit,
     onNewEventEndMinuteChange: (Int) -> Unit,
     onAddEvent: () -> Unit,
+    onDeleteEvent: (String) -> Unit,
+    onShowEventDetail: (String) -> Unit,
+    onBackToCalendar: () -> Unit
+) {
+    when (val screen = uiState.currentScreen) {
+        CalendarNavScreen.Month -> CalendarMonthView(
+            uiState = uiState,
+            onPreviousMonth = onPreviousMonth,
+            onNextMonth = onNextMonth,
+            onGoToToday = onGoToToday,
+            onDaySelected = onDaySelected,
+            onShowCreateEvent = onShowCreateEvent,
+            onShowEventDetail = onShowEventDetail,
+            onDeleteEvent = onDeleteEvent
+        )
+        CalendarNavScreen.CreateEvent -> CreateEventScreen(
+            uiState = uiState,
+            onDismiss = onDismissCreateEvent,
+            onTitleChange = onNewEventTitleChange,
+            onDescriptionChange = onNewEventDescriptionChange,
+            onTypeChange = onNewEventTypeChange,
+            onStartHourChange = onNewEventStartHourChange,
+            onStartMinuteChange = onNewEventStartMinuteChange,
+            onEndHourChange = onNewEventEndHourChange,
+            onEndMinuteChange = onNewEventEndMinuteChange,
+            onSave = onAddEvent
+        )
+        is CalendarNavScreen.EventDetail -> {
+            val event = uiState.events.find { it.id == screen.eventId }
+            if (event != null) {
+                EventDetailScreen(
+                    event = event,
+                    onBack = onBackToCalendar,
+                    onDelete = { onDeleteEvent(event.id) }
+                )
+            } else {
+                LaunchedEffect(screen.eventId) { onBackToCalendar() }
+            }
+        }
+    }
+}
+
+// ── Month view ────────────────────────────────────────────────
+
+@Composable
+private fun CalendarMonthView(
+    uiState: CalendarUiState,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit,
+    onGoToToday: () -> Unit,
+    onDaySelected: (Int) -> Unit,
+    onShowCreateEvent: () -> Unit,
+    onShowEventDetail: (String) -> Unit,
     onDeleteEvent: (String) -> Unit
 ) {
     Box(
@@ -90,6 +136,8 @@ fun CalendarScreen(
                 onGoToToday = onGoToToday
             )
 
+            WeekdayHeaders()
+
             CalendarGrid(
                 year = uiState.displayedYear,
                 month = uiState.displayedMonth,
@@ -98,41 +146,29 @@ fun CalendarScreen(
                 onDaySelected = onDaySelected
             )
 
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .padding(horizontal = 16.dp)
-                    .background(
-                        Brush.linearGradient(
-                            listOf(Color.White.copy(alpha = 0.05f), Color.White.copy(alpha = 0.15f))
-                        )
-                    )
-            )
-
-            EventsSection(
+            EventsPanel(
                 modifier = Modifier.weight(1f),
                 year = uiState.displayedYear,
                 month = uiState.displayedMonth,
                 selectedDay = uiState.selectedDay,
                 events = uiState.events,
+                onShowEventDetail = onShowEventDetail,
                 onDeleteEvent = onDeleteEvent
             )
         }
 
+        // FAB — rounded square, gradient
         Box(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(20.dp)
+                .padding(end = 20.dp, bottom = 20.dp)
                 .size(56.dp)
                 .background(
-                    Brush.linearGradient(
-                        listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))
-                    ),
-                    CircleShape
+                    Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))),
+                    RoundedCornerShape(16.dp)
                 )
-                .clip(CircleShape)
-                .clickable(onClick = onShowAddEvent),
+                .clip(RoundedCornerShape(16.dp))
+                .clickable(onClick = onShowCreateEvent),
             contentAlignment = Alignment.Center
         ) {
             Icon(
@@ -142,23 +178,10 @@ fun CalendarScreen(
                 modifier = Modifier.size(28.dp)
             )
         }
-
-        if (uiState.showAddEventDialog) {
-            AddEventDialog(
-                uiState = uiState,
-                onDismiss = onDismissAddEvent,
-                onTitleChange = onNewEventTitleChange,
-                onDescriptionChange = onNewEventDescriptionChange,
-                onTypeChange = onNewEventTypeChange,
-                onStartHourChange = onNewEventStartHourChange,
-                onStartMinuteChange = onNewEventStartMinuteChange,
-                onEndHourChange = onNewEventEndHourChange,
-                onEndMinuteChange = onNewEventEndMinuteChange,
-                onConfirm = onAddEvent
-            )
-        }
     }
 }
+
+// ── Top bar ───────────────────────────────────────────────────
 
 @Composable
 private fun CalendarTopBar(
@@ -174,29 +197,35 @@ private fun CalendarTopBar(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 12.dp),
+            .padding(start = 20.dp, end = 8.dp, top = 16.dp, bottom = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = stringResource(R.string.app_calendar_title),
-            color = Color.White,
-            fontWeight = FontWeight.Bold,
-            fontSize = 20.sp,
-            modifier = Modifier
-                .padding(start = 8.dp)
-                .weight(1f)
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = monthName,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 28.sp,
+                lineHeight = 30.sp
+            )
+            Text(
+                text = year.toString(),
+                color = Color.White.copy(alpha = 0.55f),
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp
+            )
+        }
 
         Box(
             modifier = Modifier
                 .background(
                     Brush.linearGradient(
-                        listOf(Color(0xFF6366F1).copy(alpha = 0.3f), Color(0xFF8B5CF6).copy(alpha = 0.3f))
+                        listOf(Color(0xFF6366F1).copy(alpha = 0.35f), Color(0xFF8B5CF6).copy(alpha = 0.35f))
                     ),
                     RoundedCornerShape(20.dp)
                 )
                 .clickable(onClick = onGoToToday)
-                .padding(horizontal = 12.dp, vertical = 6.dp)
+                .padding(horizontal = 14.dp, vertical = 8.dp)
         ) {
             Text(
                 text = stringResource(R.string.btn_today),
@@ -206,8 +235,6 @@ private fun CalendarTopBar(
             )
         }
 
-        Spacer(modifier = Modifier.width(8.dp))
-
         IconButton(onClick = onPreviousMonth) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
@@ -215,15 +242,6 @@ private fun CalendarTopBar(
                 tint = Color.White
             )
         }
-
-        Text(
-            text = stringResource(R.string.format_month_year, monthName, year),
-            color = Color.White,
-            fontWeight = FontWeight.SemiBold,
-            fontSize = 16.sp,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.width(140.dp)
-        )
 
         IconButton(onClick = onNextMonth) {
             Icon(
@@ -234,6 +252,31 @@ private fun CalendarTopBar(
         }
     }
 }
+
+// ── Weekday headers ───────────────────────────────────────────
+
+@Composable
+private fun WeekdayHeaders() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        stringArrayResource(R.array.calendar_day_headers).forEach { label ->
+            Text(
+                text = label,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                color = Color.White.copy(alpha = 0.50f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.sp
+            )
+        }
+    }
+}
+
+// ── Calendar grid ─────────────────────────────────────────────
 
 @Composable
 private fun CalendarGrid(
@@ -250,28 +293,14 @@ private fun CalendarGrid(
 
     val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, 1) }
     val daysInMonth = cal.getActualMaximum(java.util.Calendar.DAY_OF_MONTH)
-    val firstDayOfWeek = cal.get(java.util.Calendar.DAY_OF_WEEK) - 1
+    // Monday-first offset: Mon=0, Tue=1, …, Sun=6
+    val firstDayOfWeek = (cal.get(java.util.Calendar.DAY_OF_WEEK) - java.util.Calendar.MONDAY + 7) % 7
 
     val cells = List(firstDayOfWeek) { 0 } + (1..daysInMonth).toList()
     val remainder = cells.size % 7
     val paddedCells = if (remainder == 0) cells else cells + List(7 - remainder) { 0 }
 
-    Column(modifier = Modifier.padding(horizontal = 8.dp)) {
-        Row(modifier = Modifier.fillMaxWidth()) {
-            stringArrayResource(R.array.calendar_day_headers).forEach { dayLabel ->
-                Text(
-                    text = dayLabel,
-                    modifier = Modifier.weight(1f),
-                    textAlign = TextAlign.Center,
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(4.dp))
-
+    Column(modifier = Modifier.padding(horizontal = 6.dp)) {
         paddedCells.chunked(7).forEach { week ->
             Row(modifier = Modifier.fillMaxWidth()) {
                 week.forEach { day ->
@@ -279,9 +308,9 @@ private fun CalendarGrid(
                         day = day,
                         isToday = day != 0 && year == todayYear && month == todayMonth && day == todayDay,
                         isSelected = day != 0 && day == selectedDay,
-                        hasEvents = day != 0 && events.any {
+                        dayEvents = if (day != 0) events.filter {
                             it.year == year && it.month == month && it.day == day
-                        },
+                        } else emptyList(),
                         onClick = { if (day != 0) onDaySelected(day) },
                         modifier = Modifier.weight(1f)
                     )
@@ -296,68 +325,83 @@ private fun CalendarDayCell(
     day: Int,
     isToday: Boolean,
     isSelected: Boolean,
-    hasEvents: Boolean,
+    dayEvents: List<CalendarEvent>,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
-            .aspectRatio(1f)
-            .padding(3.dp),
-        contentAlignment = Alignment.Center
+            .height(72.dp)
+            .padding(2.dp),
+        contentAlignment = Alignment.TopCenter
     ) {
         if (day != 0) {
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .then(
                         when {
                             isSelected -> Modifier.background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))
-                                ),
-                                CircleShape
+                                Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))),
+                                RoundedCornerShape(14.dp)
                             )
                             isToday -> Modifier.background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFF06B6D4), Color(0xFF3B82F6))
-                                ),
-                                CircleShape
+                                Brush.linearGradient(listOf(Color(0xFF06B6D4), Color(0xFF3B82F6))),
+                                RoundedCornerShape(14.dp)
                             )
-                            else -> Modifier
+                            else -> Modifier.background(
+                                Color.White.copy(alpha = 0.04f),
+                                RoundedCornerShape(14.dp)
+                            )
                         }
                     )
-                    .clip(CircleShape)
-                    .clickable(onClick = onClick),
-                contentAlignment = Alignment.Center
+                    .clip(RoundedCornerShape(14.dp))
+                    .clickable(onClick = onClick)
+                    .padding(top = 8.dp, start = 4.dp, end = 4.dp, bottom = 4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        text = day.toString(),
-                        color = when {
-                            isSelected || isToday -> Color.White
-                            else -> Color.White.copy(alpha = 0.87f)
-                        },
-                        fontSize = 13.sp,
-                        fontWeight = if (isSelected || isToday) FontWeight.Bold else FontWeight.Normal,
-                        textAlign = TextAlign.Center
-                    )
-                    if (hasEvents) {
-                        Spacer(modifier = Modifier.height(1.dp))
-                        Box(
-                            modifier = Modifier
-                                .size(4.dp)
-                                .background(
-                                    brush = if (isSelected || isToday)
-                                        Brush.linearGradient(listOf(Color.White.copy(alpha = 0.87f), Color.White))
-                                    else
-                                        Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))),
-                                    shape = CircleShape
-                                )
-                        )
+                Text(
+                    text = day.toString(),
+                    color = if (isSelected || isToday) Color.White else Color.White.copy(alpha = 0.87f),
+                    fontSize = 14.sp,
+                    fontWeight = if (isSelected || isToday) FontWeight.Bold else FontWeight.Medium,
+                    textAlign = TextAlign.Center
+                )
+
+                if (dayEvents.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 3.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        dayEvents.take(3).forEach { event ->
+                            val (sc, ec) = event.type.gradientColors()
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(4.dp)
+                                    .background(
+                                        if (isSelected || isToday)
+                                            Brush.linearGradient(
+                                                listOf(Color.White.copy(alpha = 0.75f), Color.White)
+                                            )
+                                        else
+                                            Brush.linearGradient(listOf(sc, ec)),
+                                        RoundedCornerShape(2.dp)
+                                    )
+                            )
+                        }
+                        if (dayEvents.size > 3) {
+                            Text(
+                                text = "+${dayEvents.size - 3}",
+                                color = if (isSelected || isToday) Color.White.copy(alpha = 0.80f)
+                                        else Color.White.copy(alpha = 0.50f),
+                                fontSize = 8.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
                     }
                 }
             }
@@ -365,24 +409,51 @@ private fun CalendarDayCell(
     }
 }
 
+// ── Events panel (bottom sheet style) ────────────────────────
+
 @Composable
-private fun EventsSection(
+private fun EventsPanel(
     modifier: Modifier = Modifier,
     year: Int,
     month: Int,
     selectedDay: Int?,
     events: List<CalendarEvent>,
+    onShowEventDetail: (String) -> Unit,
     onDeleteEvent: (String) -> Unit
 ) {
-    val selectedEvents = events.filter { e ->
-        e.year == year && e.month == month && e.day == selectedDay
-    }.sortedWith(compareBy({ it.startHour }, { it.startMinute }))
+    val selectedEvents = if (selectedDay != null) {
+        events.filter { it.year == year && it.month == month && it.day == selectedDay }
+            .sortedWith(compareBy({ it.startHour }, { it.startMinute }))
+    } else emptyList()
 
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.linearGradient(listOf(Color(0xFF1A1741), Color(0xFF2D2A5E))),
+                RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+            )
+    ) {
+        // Drag handle
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp, bottom = 6.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(36.dp)
+                    .height(4.dp)
+                    .background(Color.White.copy(alpha = 0.22f), RoundedCornerShape(2.dp))
+            )
+        }
+
+        // Day header row
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 18.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
@@ -394,77 +465,38 @@ private fun EventsSection(
                 },
                 color = Color.White,
                 fontWeight = FontWeight.Bold,
-                fontSize = 16.sp,
+                fontSize = 17.sp,
                 modifier = Modifier.weight(1f)
             )
-
-            if (selectedDay != null) {
+            if (selectedDay != null && selectedEvents.isNotEmpty()) {
                 Text(
                     text = pluralStringResource(R.plurals.events_count, selectedEvents.size, selectedEvents.size),
-                    color = Color.White.copy(alpha = 0.87f),
+                    color = Color.White.copy(alpha = 0.55f),
                     fontSize = 13.sp
                 )
             }
         }
 
-        if (selectedDay == null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .background(
-                        Brush.linearGradient(
-                            listOf(
-                                Color(0xFF6366F1).copy(alpha = 0.08f),
-                                Color(0xFF8B5CF6).copy(alpha = 0.08f)
-                            )
-                        ),
-                        RoundedCornerShape(12.dp)
+        Spacer(modifier = Modifier.height(4.dp))
+
+        when {
+            selectedDay == null -> PanelEmptyState(stringResource(R.string.events_tap_to_select))
+            selectedEvents.isEmpty() -> PanelEmptyState(stringResource(R.string.events_no_events))
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(
+                        start = 16.dp, end = 16.dp, bottom = 88.dp
                     )
-                    .padding(20.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(R.string.events_tap_to_select),
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 14.sp,
-                    textAlign = TextAlign.Center
-                )
-            }
-        } else if (selectedEvents.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .background(
-                        Brush.linearGradient(
-                            listOf(
-                                Color(0xFF6366F1).copy(alpha = 0.08f),
-                                Color(0xFF8B5CF6).copy(alpha = 0.08f)
-                            )
-                        ),
-                        RoundedCornerShape(12.dp)
-                    )
-                    .padding(20.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = stringResource(R.string.events_no_events),
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 14.sp,
-                    textAlign = TextAlign.Center
-                )
-            }
-        } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                    start = 16.dp, end = 16.dp, bottom = 80.dp
-                )
-            ) {
-                items(selectedEvents, key = { it.id }) { event ->
-                    EventCard(event = event, onDelete = { onDeleteEvent(event.id) })
+                ) {
+                    items(selectedEvents, key = { it.id }) { event ->
+                        EventPanelCard(
+                            event = event,
+                            onTap = { onShowEventDetail(event.id) },
+                            onDelete = { onDeleteEvent(event.id) }
+                        )
+                    }
                 }
             }
         }
@@ -472,8 +504,33 @@ private fun EventsSection(
 }
 
 @Composable
-private fun EventCard(
+private fun PanelEmptyState(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .background(
+                Brush.linearGradient(
+                    listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
+                ),
+                RoundedCornerShape(12.dp)
+            )
+            .padding(20.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            color = Color.White.copy(alpha = 0.55f),
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun EventPanelCard(
     event: CalendarEvent,
+    onTap: () -> Unit,
     onDelete: () -> Unit
 ) {
     val (startColor, endColor) = event.type.gradientColors()
@@ -485,18 +542,20 @@ private fun EventCard(
                 Brush.linearGradient(
                     listOf(startColor.copy(alpha = 0.12f), endColor.copy(alpha = 0.12f))
                 ),
-                RoundedCornerShape(12.dp)
+                RoundedCornerShape(14.dp)
             )
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(onClick = onTap)
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
             modifier = Modifier
-                .width(4.dp)
-                .height(44.dp)
+                .width(5.dp)
+                .height(46.dp)
                 .background(
                     Brush.verticalGradient(listOf(startColor, endColor)),
-                    RoundedCornerShape(2.dp)
+                    RoundedCornerShape(3.dp)
                 )
         )
 
@@ -509,7 +568,7 @@ private fun EventCard(
                 fontWeight = FontWeight.SemiBold,
                 fontSize = 15.sp
             )
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.height(3.dp))
             Text(
                 text = stringResource(
                     R.string.event_time_range,
@@ -518,14 +577,14 @@ private fun EventCard(
                     event.endHour.padded(),
                     event.endMinute.padded()
                 ),
-                color = Color.White.copy(alpha = 0.87f),
+                color = Color.White.copy(alpha = 0.58f),
                 fontSize = 12.sp
             )
             if (event.description.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = event.description,
-                    color = Color.White.copy(alpha = 0.87f),
+                    color = Color.White.copy(alpha = 0.50f),
                     fontSize = 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -560,344 +619,18 @@ private fun EventCard(
             Icon(
                 imageVector = Icons.Filled.Delete,
                 contentDescription = stringResource(R.string.cd_delete_event),
-                tint = Color.White.copy(alpha = 0.87f),
+                tint = Color.White.copy(alpha = 0.50f),
                 modifier = Modifier.size(18.dp)
             )
         }
     }
 }
 
-@Composable
-private fun AddEventDialog(
-    uiState: CalendarUiState,
-    onDismiss: () -> Unit,
-    onTitleChange: (String) -> Unit,
-    onDescriptionChange: (String) -> Unit,
-    onTypeChange: (EventType) -> Unit,
-    onStartHourChange: (Int) -> Unit,
-    onStartMinuteChange: (Int) -> Unit,
-    onEndHourChange: (Int) -> Unit,
-    onEndMinuteChange: (Int) -> Unit,
-    onConfirm: () -> Unit
-) {
-    Dialog(onDismissRequest = onDismiss) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    Brush.verticalGradient(
-                        listOf(Color(0xFF1A1741), Color(0xFF2D2A5E))
-                    ),
-                    RoundedCornerShape(20.dp)
-                )
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(20.dp)
-            ) {
-                Text(
-                    text = stringResource(R.string.dialog_add_event_title),
-                    color = Color.White,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 18.sp
-                )
+// ── Shared helpers ─────────────────────────────────────────────
 
-                Spacer(modifier = Modifier.height(16.dp))
+internal fun Int.padded(): String = toString().padStart(2, '0')
 
-                OutlinedTextField(
-                    value = uiState.newEventTitle,
-                    onValueChange = onTitleChange,
-                    label = {
-                        Text(
-                            stringResource(R.string.dialog_event_title_hint),
-                            color = Color.White.copy(alpha = 0.87f)
-                        )
-                    },
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White.copy(alpha = 0.87f),
-                        focusedBorderColor = Color(0xFF6366F1),
-                        unfocusedBorderColor = Color.White.copy(alpha = 0.25f),
-                        cursorColor = Color(0xFF6366F1),
-                        focusedLabelColor = Color(0xFF6366F1),
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.87f)
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                OutlinedTextField(
-                    value = uiState.newEventDescription,
-                    onValueChange = onDescriptionChange,
-                    label = {
-                        Text(
-                            stringResource(R.string.dialog_event_desc_hint),
-                            color = Color.White.copy(alpha = 0.87f)
-                        )
-                    },
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White.copy(alpha = 0.87f),
-                        focusedBorderColor = Color(0xFF6366F1),
-                        unfocusedBorderColor = Color.White.copy(alpha = 0.25f),
-                        cursorColor = Color(0xFF6366F1),
-                        focusedLabelColor = Color(0xFF6366F1),
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.87f)
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
-                    maxLines = 2
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = stringResource(R.string.dialog_event_type_label),
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    EventType.entries.forEach { type ->
-                        val isSelected = uiState.newEventType == type
-                        val (sc, ec) = type.gradientColors()
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .background(
-                                    if (isSelected) {
-                                        Brush.linearGradient(listOf(sc, ec))
-                                    } else {
-                                        Brush.linearGradient(
-                                            listOf(sc.copy(alpha = 0.15f), ec.copy(alpha = 0.15f))
-                                        )
-                                    },
-                                    RoundedCornerShape(8.dp)
-                                )
-                                .clip(RoundedCornerShape(8.dp))
-                                .clickable { onTypeChange(type) }
-                                .padding(vertical = 6.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = stringResource(type.labelRes),
-                                color = Color.White,
-                                fontSize = 11.sp,
-                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                textAlign = TextAlign.Center
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.dialog_start_time),
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontSize = 13.sp,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                        Spacer(modifier = Modifier.height(6.dp))
-                        TimeSelector(
-                            hour = uiState.newEventStartHour,
-                            minute = uiState.newEventStartMinute,
-                            onHourChange = onStartHourChange,
-                            onMinuteChange = onStartMinuteChange,
-                            hourContentDescription = stringResource(R.string.cd_start_hour),
-                            minuteContentDescription = stringResource(R.string.cd_start_minute)
-                        )
-                    }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.dialog_end_time),
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontSize = 13.sp,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                        Spacer(modifier = Modifier.height(6.dp))
-                        TimeSelector(
-                            hour = uiState.newEventEndHour,
-                            minute = uiState.newEventEndMinute,
-                            onHourChange = onEndHourChange,
-                            onMinuteChange = onEndMinuteChange,
-                            hourContentDescription = stringResource(R.string.cd_end_hour),
-                            minuteContentDescription = stringResource(R.string.cd_end_minute)
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(20.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .background(
-                                Brush.linearGradient(
-                                    listOf(
-                                        Color.White.copy(alpha = 0.05f),
-                                        Color.White.copy(alpha = 0.12f)
-                                    )
-                                ),
-                                RoundedCornerShape(12.dp)
-                            )
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable(onClick = onDismiss)
-                            .padding(vertical = 13.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = stringResource(R.string.btn_cancel),
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontWeight = FontWeight.SemiBold
-                        )
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .background(
-                                if (uiState.newEventTitle.isNotBlank()) {
-                                    Brush.linearGradient(
-                                        listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))
-                                    )
-                                } else {
-                                    Brush.linearGradient(
-                                        listOf(
-                                            Color(0xFF6366F1).copy(alpha = 0.4f),
-                                            Color(0xFF8B5CF6).copy(alpha = 0.4f)
-                                        )
-                                    )
-                                },
-                                RoundedCornerShape(12.dp)
-                            )
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable(
-                                enabled = uiState.newEventTitle.isNotBlank(),
-                                onClick = onConfirm
-                            )
-                            .padding(vertical = 13.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = stringResource(R.string.btn_add_event),
-                            color = Color.White,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun TimeSelector(
-    hour: Int,
-    minute: Int,
-    onHourChange: (Int) -> Unit,
-    onMinuteChange: (Int) -> Unit,
-    hourContentDescription: String,
-    minuteContentDescription: String
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                Brush.linearGradient(
-                    listOf(Color.White.copy(alpha = 0.05f), Color.White.copy(alpha = 0.10f))
-                ),
-                RoundedCornerShape(10.dp)
-            )
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        TimeSpinner(
-            value = hour,
-            onIncrement = { onHourChange((hour + 1) % 24) },
-            onDecrement = { onHourChange((hour - 1 + 24) % 24) },
-            contentDescription = hourContentDescription
-        )
-
-        Text(
-            text = stringResource(R.string.time_separator),
-            color = Color.White,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(horizontal = 4.dp)
-        )
-
-        TimeSpinner(
-            value = minute,
-            onIncrement = { onMinuteChange((minute + 15) % 60) },
-            onDecrement = { onMinuteChange((minute - 15 + 60) % 60) },
-            contentDescription = minuteContentDescription
-        )
-    }
-}
-
-@Composable
-private fun TimeSpinner(
-    value: Int,
-    onIncrement: () -> Unit,
-    onDecrement: () -> Unit,
-    contentDescription: String
-) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        IconButton(
-            onClick = onIncrement,
-            modifier = Modifier.size(48.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowUp,
-                contentDescription = stringResource(R.string.cd_increase_value, contentDescription),
-                tint = Color.White.copy(alpha = 0.87f),
-                modifier = Modifier.size(18.dp)
-            )
-        }
-        Text(
-            text = value.padded(),
-            color = Color.White,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center
-        )
-        IconButton(
-            onClick = onDecrement,
-            modifier = Modifier.size(48.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowDown,
-                contentDescription = stringResource(R.string.cd_decrease_value, contentDescription),
-                tint = Color.White.copy(alpha = 0.87f),
-                modifier = Modifier.size(18.dp)
-            )
-        }
-    }
-}
-
-private fun Int.padded(): String = toString().padStart(2, '0')
-
-private fun EventType.gradientColors(): Pair<Color, Color> = when (this) {
+internal fun EventType.gradientColors(): Pair<Color, Color> = when (this) {
     EventType.WORK -> Color(0xFF6366F1) to Color(0xFF8B5CF6)
     EventType.PERSONAL -> Color(0xFF06B6D4) to Color(0xFF3B82F6)
     EventType.HEALTH -> Color(0xFF10B981) to Color(0xFF059669)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -447,7 +447,12 @@ private fun EventsPanel(
                 modifier = Modifier
                     .width(36.dp)
                     .height(4.dp)
-                    .background(Color.White.copy(alpha = 0.22f), RoundedCornerShape(2.dp))
+                    .background(
+                        Brush.linearGradient(
+                            listOf(Color.White.copy(alpha = 0.15f), Color.White.copy(alpha = 0.28f))
+                        ),
+                        RoundedCornerShape(2.dp)
+                    )
             )
         }
 

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -397,7 +397,7 @@ private fun CalendarDayCell(
                         }
                         if (dayEvents.size > 3) {
                             Text(
-                                text = "+${dayEvents.size - 3}",
+                                text = stringResource(R.string.events_overflow_count, dayEvents.size - 3),
                                 color = if (isSelected || isToday) Color.White.copy(alpha = 0.80f)
                                         else Color.White.copy(alpha = 0.50f),
                                 fontSize = 8.sp,

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarUiState.kt
@@ -3,13 +3,19 @@ package com.example.testingapplictionandriod.ui.calendar
 import com.example.testingapplictionandriod.domain.model.CalendarEvent
 import com.example.testingapplictionandriod.domain.model.EventType
 
+sealed class CalendarNavScreen {
+    object Month : CalendarNavScreen()
+    object CreateEvent : CalendarNavScreen()
+    data class EventDetail(val eventId: String) : CalendarNavScreen()
+}
+
 data class CalendarUiState(
     val displayedYear: Int = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR),
     val displayedMonth: Int = java.util.Calendar.getInstance().get(java.util.Calendar.MONTH) + 1,
     val selectedDay: Int? = null,
     val events: List<CalendarEvent> = emptyList(),
     val isLoading: Boolean = false,
-    val showAddEventDialog: Boolean = false,
+    val currentScreen: CalendarNavScreen = CalendarNavScreen.Month,
     val newEventTitle: String = "",
     val newEventDescription: String = "",
     val newEventType: EventType = EventType.PERSONAL,

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModel.kt
@@ -54,14 +54,14 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
         _uiState.update { it.copy(selectedDay = day) }
     }
 
-    fun onShowAddEvent() {
-        _uiState.update { it.copy(showAddEventDialog = true) }
+    fun onShowCreateEvent() {
+        _uiState.update { it.copy(currentScreen = CalendarNavScreen.CreateEvent) }
     }
 
-    fun onDismissAddEvent() {
+    fun onDismissCreateEvent() {
         _uiState.update {
             it.copy(
-                showAddEventDialog = false,
+                currentScreen = CalendarNavScreen.Month,
                 newEventTitle = "",
                 newEventDescription = "",
                 newEventType = EventType.PERSONAL,
@@ -71,6 +71,14 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
                 newEventEndMinute = 0
             )
         }
+    }
+
+    fun onShowEventDetail(eventId: String) {
+        _uiState.update { it.copy(currentScreen = CalendarNavScreen.EventDetail(eventId)) }
+    }
+
+    fun onBackToCalendar() {
+        _uiState.update { it.copy(currentScreen = CalendarNavScreen.Month) }
     }
 
     fun onNewEventTitleChange(title: String) {
@@ -125,7 +133,7 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
         _uiState.update {
             it.copy(
                 events = it.events + event,
-                showAddEventDialog = false,
+                currentScreen = CalendarNavScreen.Month,
                 newEventTitle = "",
                 newEventDescription = "",
                 newEventType = EventType.PERSONAL,
@@ -138,18 +146,20 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
     }
 
     fun onDeleteEvent(eventId: String) {
-        _uiState.update { it.copy(events = it.events.filter { e -> e.id != eventId }) }
+        _uiState.update {
+            it.copy(
+                events = it.events.filter { e -> e.id != eventId },
+                currentScreen = CalendarNavScreen.Month
+            )
+        }
     }
 
     private companion object {
         fun buildInitialState(): CalendarUiState {
             val today = java.util.Calendar.getInstance()
-            val year = today.get(java.util.Calendar.YEAR)
-            val month = today.get(java.util.Calendar.MONTH) + 1
-
             return CalendarUiState(
-                displayedYear = year,
-                displayedMonth = month,
+                displayedYear = today.get(java.util.Calendar.YEAR),
+                displayedMonth = today.get(java.util.Calendar.MONTH) + 1,
                 events = emptyList()
             )
         }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
@@ -170,10 +170,10 @@ fun CreateEventScreen(
                     val cal = java.util.Calendar.getInstance().apply {
                         set(uiState.displayedYear, uiState.displayedMonth - 1, day)
                     }
-                    SimpleDateFormat("EEE, MMM d, yyyy", Locale.getDefault()).format(cal.time)
+                    SimpleDateFormat(stringResource(R.string.date_format_full), Locale.getDefault()).format(cal.time)
                 } ?: run {
                     val cal = java.util.Calendar.getInstance()
-                    SimpleDateFormat("EEE, MMM d, yyyy", Locale.getDefault()).format(cal.time)
+                    SimpleDateFormat(stringResource(R.string.date_format_full), Locale.getDefault()).format(cal.time)
                 }
 
                 Row(
@@ -296,7 +296,7 @@ fun CreateEventScreen(
                             if (uiState.newEventDescription.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.hint_add_notes),
-                                    color = Color.White.copy(alpha = 0.28f),
+                                    color = Color.White.copy(alpha = 0.87f),
                                     fontSize = 15.sp
                                 )
                             }
@@ -375,7 +375,7 @@ private fun SpinnerWheel(
     description: String
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        IconButton(onClick = onIncrement, modifier = Modifier.size(40.dp)) {
+        IconButton(onClick = onIncrement, modifier = Modifier.size(48.dp)) {
             Icon(
                 imageVector = Icons.Filled.KeyboardArrowUp,
                 contentDescription = stringResource(R.string.cd_increase_value, description),
@@ -390,7 +390,7 @@ private fun SpinnerWheel(
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center
         )
-        IconButton(onClick = onDecrement, modifier = Modifier.size(40.dp)) {
+        IconButton(onClick = onDecrement, modifier = Modifier.size(48.dp)) {
             Icon(
                 imageVector = Icons.Filled.KeyboardArrowDown,
                 contentDescription = stringResource(R.string.cd_decrease_value, description),

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
@@ -1,0 +1,383 @@
+package com.example.testingapplictionandriod.ui.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.R
+import com.example.testingapplictionandriod.domain.model.EventType
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@Composable
+fun CreateEventScreen(
+    uiState: CalendarUiState,
+    onDismiss: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onDescriptionChange: (String) -> Unit,
+    onTypeChange: (EventType) -> Unit,
+    onStartHourChange: (Int) -> Unit,
+    onStartMinuteChange: (Int) -> Unit,
+    onEndHourChange: (Int) -> Unit,
+    onEndMinuteChange: (Int) -> Unit,
+    onSave: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
+                )
+            )
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Top bar: close | title | save
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = stringResource(R.string.cd_close),
+                        tint = Color.White
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.screen_create_event),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 4.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .background(
+                            if (uiState.newEventTitle.isNotBlank())
+                                Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6)))
+                            else
+                                Brush.linearGradient(
+                                    listOf(
+                                        Color(0xFF6366F1).copy(alpha = 0.40f),
+                                        Color(0xFF8B5CF6).copy(alpha = 0.40f)
+                                    )
+                                ),
+                            RoundedCornerShape(999.dp)
+                        )
+                        .clip(RoundedCornerShape(999.dp))
+                        .clickable(enabled = uiState.newEventTitle.isNotBlank(), onClick = onSave)
+                        .padding(horizontal = 20.dp, vertical = 10.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.btn_save),
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 14.sp
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+
+            // Scrollable form body
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp, vertical = 4.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                // Large title input
+                BasicTextField(
+                    value = uiState.newEventTitle,
+                    onValueChange = onTitleChange,
+                    textStyle = TextStyle(
+                        color = Color.White,
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    cursorBrush = SolidColor(Color(0xFF6366F1)),
+                    decorationBox = { innerField ->
+                        Box(modifier = Modifier.fillMaxWidth()) {
+                            if (uiState.newEventTitle.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.hint_event_title),
+                                    color = Color.White.copy(alpha = 0.30f),
+                                    fontSize = 28.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                            innerField()
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                )
+
+                // Subtle divider
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Color.White.copy(alpha = 0.10f))
+                )
+
+                // Date row
+                val dateLabel = uiState.selectedDay?.let { day ->
+                    val cal = java.util.Calendar.getInstance().apply {
+                        set(uiState.displayedYear, uiState.displayedMonth - 1, day)
+                    }
+                    SimpleDateFormat("EEE, MMM d, yyyy", Locale.getDefault()).format(cal.time)
+                } ?: run {
+                    val cal = java.util.Calendar.getInstance()
+                    SimpleDateFormat("EEE, MMM d, yyyy", Locale.getDefault()).format(cal.time)
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.DateRange,
+                        contentDescription = stringResource(R.string.label_date),
+                        tint = Color(0xFF6366F1),
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Text(
+                        text = dateLabel,
+                        color = Color.White,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                // Start / End time row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        SectionLabel(text = stringResource(R.string.dialog_start_time))
+                        Spacer(modifier = Modifier.height(6.dp))
+                        TimeSpinnerBlock(
+                            hour = uiState.newEventStartHour,
+                            minute = uiState.newEventStartMinute,
+                            onHourChange = onStartHourChange,
+                            onMinuteChange = onStartMinuteChange,
+                            hourDescription = stringResource(R.string.cd_start_hour),
+                            minuteDescription = stringResource(R.string.cd_start_minute)
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        SectionLabel(text = stringResource(R.string.dialog_end_time))
+                        Spacer(modifier = Modifier.height(6.dp))
+                        TimeSpinnerBlock(
+                            hour = uiState.newEventEndHour,
+                            minute = uiState.newEventEndMinute,
+                            onHourChange = onEndHourChange,
+                            onMinuteChange = onEndMinuteChange,
+                            hourDescription = stringResource(R.string.cd_end_hour),
+                            minuteDescription = stringResource(R.string.cd_end_minute)
+                        )
+                    }
+                }
+
+                // Event type chips
+                SectionLabel(text = stringResource(R.string.dialog_event_type_label))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    EventType.entries.forEach { type ->
+                        val isSelected = uiState.newEventType == type
+                        val (sc, ec) = type.gradientColors()
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .background(
+                                    if (isSelected) Brush.linearGradient(listOf(sc, ec))
+                                    else Brush.linearGradient(
+                                        listOf(sc.copy(alpha = 0.15f), ec.copy(alpha = 0.15f))
+                                    ),
+                                    RoundedCornerShape(10.dp)
+                                )
+                                .clip(RoundedCornerShape(10.dp))
+                                .clickable { onTypeChange(type) }
+                                .padding(vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = stringResource(type.labelRes),
+                                color = Color.White,
+                                fontSize = 11.sp,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
+
+                // Notes / description
+                SectionLabel(text = stringResource(R.string.label_notes))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+                        .padding(16.dp)
+                ) {
+                    BasicTextField(
+                        value = uiState.newEventDescription,
+                        onValueChange = onDescriptionChange,
+                        textStyle = TextStyle(
+                            color = Color.White,
+                            fontSize = 15.sp
+                        ),
+                        cursorBrush = SolidColor(Color(0xFF6366F1)),
+                        minLines = 3,
+                        decorationBox = { innerField ->
+                            if (uiState.newEventDescription.isEmpty()) {
+                                Text(
+                                    text = stringResource(R.string.hint_add_notes),
+                                    color = Color.White.copy(alpha = 0.28f),
+                                    fontSize = 15.sp
+                                )
+                            }
+                            innerField()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text.uppercase(),
+        color = Color.White.copy(alpha = 0.50f),
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.8.sp
+    )
+}
+
+@Composable
+private fun TimeSpinnerBlock(
+    hour: Int,
+    minute: Int,
+    onHourChange: (Int) -> Unit,
+    onMinuteChange: (Int) -> Unit,
+    hourDescription: String,
+    minuteDescription: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(12.dp))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        SpinnerWheel(
+            value = hour,
+            onIncrement = { onHourChange((hour + 1) % 24) },
+            onDecrement = { onHourChange((hour - 1 + 24) % 24) },
+            description = hourDescription
+        )
+        Text(
+            text = stringResource(R.string.time_separator),
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 4.dp)
+        )
+        SpinnerWheel(
+            value = minute,
+            onIncrement = { onMinuteChange((minute + 15) % 60) },
+            onDecrement = { onMinuteChange((minute - 15 + 60) % 60) },
+            description = minuteDescription
+        )
+    }
+}
+
+@Composable
+private fun SpinnerWheel(
+    value: Int,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    description: String
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        IconButton(onClick = onIncrement, modifier = Modifier.size(40.dp)) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowUp,
+                contentDescription = stringResource(R.string.cd_increase_value, description),
+                tint = Color.White.copy(alpha = 0.87f),
+                modifier = Modifier.size(16.dp)
+            )
+        }
+        Text(
+            text = value.padded(),
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        IconButton(onClick = onDecrement, modifier = Modifier.size(40.dp)) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowDown,
+                contentDescription = stringResource(R.string.cd_decrease_value, description),
+                tint = Color.White.copy(alpha = 0.87f),
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
@@ -140,7 +140,7 @@ fun CreateEventScreen(
                             if (uiState.newEventTitle.isEmpty()) {
                                 Text(
                                     text = stringResource(R.string.hint_event_title),
-                                    color = Color.White.copy(alpha = 0.30f),
+                                    color = Color.White.copy(alpha = 0.87f),
                                     fontSize = 28.sp,
                                     fontWeight = FontWeight.Bold
                                 )
@@ -192,7 +192,7 @@ fun CreateEventScreen(
                     Icon(
                         imageVector = Icons.Filled.DateRange,
                         contentDescription = stringResource(R.string.label_date),
-                        tint = Color(0xFF6366F1),
+                        tint = Color.White,
                         modifier = Modifier.size(20.dp)
                     )
                     Text(
@@ -316,7 +316,7 @@ fun CreateEventScreen(
 private fun SectionLabel(text: String) {
     Text(
         text = text.uppercase(),
-        color = Color.White.copy(alpha = 0.50f),
+        color = Color.White.copy(alpha = 0.87f),
         fontSize = 11.sp,
         fontWeight = FontWeight.Bold,
         letterSpacing = 0.8.sp

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
@@ -158,7 +158,11 @@ fun CreateEventScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(1.dp)
-                        .background(Color.White.copy(alpha = 0.10f))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF6366F1).copy(alpha = 0.10f), Color(0xFF8B5CF6).copy(alpha = 0.10f))
+                            )
+                        )
                 )
 
                 // Date row
@@ -175,7 +179,12 @@ fun CreateEventScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
+                            ),
+                            RoundedCornerShape(14.dp)
+                        )
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -266,7 +275,12 @@ fun CreateEventScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
+                            ),
+                            RoundedCornerShape(14.dp)
+                        )
                         .padding(16.dp)
                 ) {
                     BasicTextField(
@@ -321,7 +335,12 @@ private fun TimeSpinnerBlock(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(12.dp))
+            .background(
+                Brush.linearGradient(
+                    listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
+                ),
+                RoundedCornerShape(12.dp)
+            )
             .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -96,7 +96,9 @@ fun EventDetailScreen(
                         Box(
                             modifier = Modifier
                                 .background(
-                                    Color.White.copy(alpha = 0.20f),
+                                    Brush.linearGradient(
+                                        listOf(Color(0xFF6366F1).copy(alpha = 0.20f), Color(0xFF8B5CF6).copy(alpha = 0.20f))
+                                    ),
                                     RoundedCornerShape(999.dp)
                                 )
                                 .padding(horizontal = 12.dp, vertical = 5.dp)
@@ -160,7 +162,12 @@ fun EventDetailScreen(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(16.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
+                            ),
+                            RoundedCornerShape(16.dp)
+                        )
                         .padding(16.dp),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
@@ -270,7 +277,11 @@ private fun StatDivider() {
         modifier = Modifier
             .width(1.dp)
             .height(36.dp)
-            .background(Color.White.copy(alpha = 0.12f))
+            .background(
+                Brush.linearGradient(
+                    listOf(Color(0xFF6366F1).copy(alpha = 0.12f), Color(0xFF8B5CF6).copy(alpha = 0.12f))
+                )
+            )
     )
 }
 
@@ -279,7 +290,12 @@ private fun DetailSection(title: String, content: @Composable () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+            .background(
+                Brush.linearGradient(
+                    listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
+                ),
+                RoundedCornerShape(14.dp)
+            )
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -1,0 +1,295 @@
+package com.example.testingapplictionandriod.ui.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.R
+import com.example.testingapplictionandriod.domain.model.CalendarEvent
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@Composable
+fun EventDetailScreen(
+    event: CalendarEvent,
+    onBack: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val (startColor, endColor) = event.type.gradientColors()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
+                )
+            )
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            // ── Hero header ──────────────────────────────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.linearGradient(listOf(startColor, endColor))
+                    )
+            ) {
+                Column {
+                    // Action row
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.cd_back),
+                                tint = Color.White
+                            )
+                        }
+                        Spacer(modifier = Modifier.weight(1f))
+                        IconButton(onClick = onDelete) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.cd_delete_event),
+                                tint = Color.White
+                            )
+                        }
+                    }
+
+                    // Event metadata
+                    Column(
+                        modifier = Modifier.padding(
+                            start = 20.dp, end = 20.dp, top = 4.dp, bottom = 28.dp
+                        )
+                    ) {
+                        // Category pill
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    Color.White.copy(alpha = 0.20f),
+                                    RoundedCornerShape(999.dp)
+                                )
+                                .padding(horizontal = 12.dp, vertical = 5.dp)
+                        ) {
+                            Text(
+                                text = stringResource(event.type.labelRes),
+                                color = Color.White,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Text(
+                            text = event.title,
+                            color = Color.White,
+                            fontSize = 30.sp,
+                            fontWeight = FontWeight.Bold,
+                            lineHeight = 34.sp
+                        )
+
+                        Spacer(modifier = Modifier.height(10.dp))
+
+                        val cal = java.util.Calendar.getInstance().apply {
+                            set(event.year, event.month - 1, event.day)
+                        }
+                        val dateStr = SimpleDateFormat(
+                            "EEEE, MMM d", Locale.getDefault()
+                        ).format(cal.time)
+                        Text(
+                            text = "$dateStr · ${event.startHour.padded()}:${event.startMinute.padded()} – ${event.endHour.padded()}:${event.endMinute.padded()}",
+                            color = Color.White.copy(alpha = 0.87f),
+                            fontSize = 14.sp
+                        )
+                    }
+                }
+            }
+
+            // ── Body content ─────────────────────────────────────
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+
+                // Stats card
+                val durationMins = (event.endHour * 60 + event.endMinute) -
+                        (event.startHour * 60 + event.startMinute)
+                val durationText = when {
+                    durationMins <= 0 -> stringResource(R.string.duration_na)
+                    durationMins < 60 -> stringResource(R.string.duration_minutes, durationMins)
+                    durationMins % 60 == 0 -> stringResource(R.string.duration_hours, durationMins / 60)
+                    else -> stringResource(
+                        R.string.duration_hours_minutes, durationMins / 60, durationMins % 60
+                    )
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(16.dp))
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    StatItem(
+                        label = stringResource(R.string.label_duration),
+                        value = durationText,
+                        color = startColor
+                    )
+                    StatDivider()
+                    StatItem(
+                        label = stringResource(R.string.label_event_type),
+                        value = stringResource(event.type.labelRes),
+                        color = endColor
+                    )
+                    StatDivider()
+                    StatItem(
+                        label = stringResource(R.string.label_date),
+                        value = "${event.day}/${event.month}",
+                        color = startColor
+                    )
+                }
+
+                // Time detail card
+                DetailSection(title = stringResource(R.string.label_time)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column {
+                            Text(
+                                text = stringResource(R.string.dialog_start_time).uppercase(),
+                                color = Color.White.copy(alpha = 0.45f),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "${event.startHour.padded()}:${event.startMinute.padded()}",
+                                color = Color.White,
+                                fontSize = 26.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        Text(
+                            text = "→",
+                            color = Color.White.copy(alpha = 0.45f),
+                            fontSize = 20.sp
+                        )
+                        Column {
+                            Text(
+                                text = stringResource(R.string.dialog_end_time).uppercase(),
+                                color = Color.White.copy(alpha = 0.45f),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "${event.endHour.padded()}:${event.endMinute.padded()}",
+                                color = Color.White,
+                                fontSize = 26.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+
+                // Description / notes card (only if non-empty)
+                if (event.description.isNotEmpty()) {
+                    DetailSection(title = stringResource(R.string.label_notes)) {
+                        Text(
+                            text = event.description,
+                            color = Color.White.copy(alpha = 0.87f),
+                            fontSize = 15.sp,
+                            lineHeight = 22.sp
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: String, color: Color) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = label,
+            color = Color.White.copy(alpha = 0.50f),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = value,
+            color = color,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun StatDivider() {
+    Box(
+        modifier = Modifier
+            .width(1.dp)
+            .height(36.dp)
+            .background(Color.White.copy(alpha = 0.12f))
+    )
+}
+
+@Composable
+private fun DetailSection(title: String, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White.copy(alpha = 0.06f), RoundedCornerShape(14.dp))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Text(
+            text = title.uppercase(),
+            color = Color.White.copy(alpha = 0.38f),
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.sp
+        )
+        content()
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -127,7 +127,7 @@ fun EventDetailScreen(
                             set(event.year, event.month - 1, event.day)
                         }
                         val dateStr = SimpleDateFormat(
-                            "EEEE, MMM d", Locale.getDefault()
+                            stringResource(R.string.date_format_day_month), Locale.getDefault()
                         ).format(cal.time)
                         Text(
                             text = stringResource(
@@ -210,7 +210,7 @@ fun EventDetailScreen(
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
-                                text = "${event.startHour.padded()}:${event.startMinute.padded()}",
+                                text = stringResource(R.string.time_hhmm, event.startHour.padded(), event.startMinute.padded()),
                                 color = Color.White,
                                 fontSize = 26.sp,
                                 fontWeight = FontWeight.Bold
@@ -218,18 +218,18 @@ fun EventDetailScreen(
                         }
                         Text(
                             text = stringResource(R.string.cd_time_arrow),
-                            color = Color.White.copy(alpha = 0.45f),
+                            color = Color.White.copy(alpha = 0.87f),
                             fontSize = 20.sp
                         )
                         Column {
                             Text(
                                 text = stringResource(R.string.dialog_end_time).uppercase(),
-                                color = Color.White.copy(alpha = 0.45f),
+                                color = Color.White.copy(alpha = 0.87f),
                                 fontSize = 11.sp,
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
-                                text = "${event.endHour.padded()}:${event.endMinute.padded()}",
+                                text = stringResource(R.string.time_hhmm, event.endHour.padded(), event.endMinute.padded()),
                                 color = Color.White,
                                 fontSize = 26.sp,
                                 fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -130,7 +130,14 @@ fun EventDetailScreen(
                             "EEEE, MMM d", Locale.getDefault()
                         ).format(cal.time)
                         Text(
-                            text = "$dateStr · ${event.startHour.padded()}:${event.startMinute.padded()} – ${event.endHour.padded()}:${event.endMinute.padded()}",
+                            text = stringResource(
+                                R.string.event_detail_datetime,
+                                dateStr,
+                                event.startHour.padded(),
+                                event.startMinute.padded(),
+                                event.endHour.padded(),
+                                event.endMinute.padded()
+                            ),
                             color = Color.White.copy(alpha = 0.87f),
                             fontSize = 14.sp
                         )
@@ -184,7 +191,7 @@ fun EventDetailScreen(
                     StatDivider()
                     StatItem(
                         label = stringResource(R.string.label_date),
-                        value = "${event.day}/${event.month}"
+                        value = stringResource(R.string.event_date_short, event.day, event.month)
                     )
                 }
 
@@ -198,7 +205,7 @@ fun EventDetailScreen(
                         Column {
                             Text(
                                 text = stringResource(R.string.dialog_start_time).uppercase(),
-                                color = Color.White.copy(alpha = 0.45f),
+                                color = Color.White.copy(alpha = 0.87f),
                                 fontSize = 11.sp,
                                 fontWeight = FontWeight.Bold
                             )
@@ -254,7 +261,7 @@ private fun StatItem(label: String, value: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = label,
-            color = Color.White.copy(alpha = 0.50f),
+            color = Color.White.copy(alpha = 0.87f),
             fontSize = 11.sp,
             fontWeight = FontWeight.SemiBold
         )
@@ -298,7 +305,7 @@ private fun DetailSection(title: String, content: @Composable () -> Unit) {
     ) {
         Text(
             text = title.uppercase(),
-            color = Color.White.copy(alpha = 0.38f),
+            color = Color.White.copy(alpha = 0.87f),
             fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 1.sp

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -174,20 +174,17 @@ fun EventDetailScreen(
                 ) {
                     StatItem(
                         label = stringResource(R.string.label_duration),
-                        value = durationText,
-                        color = startColor
+                        value = durationText
                     )
                     StatDivider()
                     StatItem(
                         label = stringResource(R.string.label_event_type),
-                        value = stringResource(event.type.labelRes),
-                        color = endColor
+                        value = stringResource(event.type.labelRes)
                     )
                     StatDivider()
                     StatItem(
                         label = stringResource(R.string.label_date),
-                        value = "${event.day}/${event.month}",
-                        color = startColor
+                        value = "${event.day}/${event.month}"
                     )
                 }
 
@@ -213,7 +210,7 @@ fun EventDetailScreen(
                             )
                         }
                         Text(
-                            text = "→",
+                            text = stringResource(R.string.cd_time_arrow),
                             color = Color.White.copy(alpha = 0.45f),
                             fontSize = 20.sp
                         )
@@ -253,7 +250,7 @@ fun EventDetailScreen(
 }
 
 @Composable
-private fun StatItem(label: String, value: String, color: Color) {
+private fun StatItem(label: String, value: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = label,
@@ -264,7 +261,7 @@ private fun StatItem(label: String, value: String, color: Color) {
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = value,
-            color = color,
+            color = Color.White,
             fontSize = 14.sp,
             fontWeight = FontWeight.Bold
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@
 
     <!-- Event time range format -->
     <string name="event_time_range">%1$s:%2$s — %3$s:%4$s</string>
+    <string name="event_detail_datetime">%1$s · %2$s:%3$s – %4$s:%5$s</string>
+    <string name="event_date_short">%1$d/%2$d</string>
 
     <!-- Calendar day headers — Monday-first (matches reference design) -->
     <string-array name="calendar_day_headers">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <!-- Date format patterns -->
     <string name="date_format_full">EEE, MMM d, yyyy</string>
     <string name="date_format_day_month">EEEE, MMM d</string>
+    <string name="date_format_month_only">MMMM</string>
 
     <!-- Time display format -->
     <string name="time_hhmm">%1$s:%2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,12 @@
     <string name="btn_today">Today</string>
     <string name="btn_cancel">Cancel</string>
     <string name="btn_add_event">Add Event</string>
+    <string name="btn_save">Save</string>
+
+    <!-- Create event screen -->
+    <string name="screen_create_event">New Event</string>
+    <string name="hint_event_title">Add title…</string>
+    <string name="hint_add_notes">Add notes…</string>
 
     <!-- Events section -->
     <string name="events_title_no_selection">My Events</string>
@@ -22,6 +28,19 @@
     <string name="dialog_start_time">Start Time</string>
     <string name="dialog_end_time">End Time</string>
 
+    <!-- Section labels -->
+    <string name="label_date">Date</string>
+    <string name="label_notes">Notes</string>
+    <string name="label_duration">Duration</string>
+    <string name="label_event_type">Type</string>
+    <string name="label_time">Time</string>
+
+    <!-- Duration formats -->
+    <string name="duration_na">N/A</string>
+    <string name="duration_minutes">%1$d min</string>
+    <string name="duration_hours">%1$d h</string>
+    <string name="duration_hours_minutes">%1$dh %2$dm</string>
+
     <!-- Content descriptions -->
     <string name="cd_add_event">Add new event</string>
     <string name="cd_delete_event">Delete event</string>
@@ -33,6 +52,8 @@
     <string name="cd_end_minute">End minute</string>
     <string name="cd_increase_value">Increase %1$s</string>
     <string name="cd_decrease_value">Decrease %1$s</string>
+    <string name="cd_close">Close</string>
+    <string name="cd_back">Go back</string>
 
     <!-- Event types -->
     <string name="event_type_work">Work</string>
@@ -47,15 +68,15 @@
     <!-- Event time range format -->
     <string name="event_time_range">%1$s:%2$s — %3$s:%4$s</string>
 
-    <!-- Calendar day headers -->
+    <!-- Calendar day headers — Monday-first (matches reference design) -->
     <string-array name="calendar_day_headers">
-        <item>Su</item>
         <item>Mo</item>
         <item>Tu</item>
         <item>We</item>
         <item>Th</item>
         <item>Fr</item>
         <item>Sa</item>
+        <item>Su</item>
     </string-array>
 
     <!-- Month/year header format -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="duration_hours_minutes">%1$dh %2$dm</string>
 
     <!-- Content descriptions -->
+    <string name="cd_time_arrow">→</string>
     <string name="cd_add_event">Add new event</string>
     <string name="cd_delete_event">Delete event</string>
     <string name="cd_previous_month">Previous month</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,16 @@
         <item>Su</item>
     </string-array>
 
+    <!-- Date format patterns -->
+    <string name="date_format_full">EEE, MMM d, yyyy</string>
+    <string name="date_format_day_month">EEEE, MMM d</string>
+
+    <!-- Time display format -->
+    <string name="time_hhmm">%1$s:%2$s</string>
+
+    <!-- Events overflow indicator -->
+    <string name="events_overflow_count">+%1$d</string>
+
     <!-- Month/year header format -->
     <string name="format_month_year">%1$s %2$d</string>
 

--- a/app/src/test/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModelTest.kt
+++ b/app/src/test/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModelTest.kt
@@ -53,6 +53,16 @@ class CalendarViewModelTest {
     }
 
     @Test
+    fun initialState_screenIsMonth() = runTest {
+        val viewModel = CalendarViewModel()
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state.currentScreen is CalendarNavScreen.Month)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun onNextMonth_incrementsMonth() = runTest {
         val viewModel = CalendarViewModel()
         viewModel.uiState.test {
@@ -161,31 +171,58 @@ class CalendarViewModelTest {
     }
 
     @Test
-    fun onShowAddEvent_setsDialogVisible() = runTest {
+    fun onShowCreateEvent_navigatesToCreateScreen() = runTest {
         val viewModel = CalendarViewModel()
         viewModel.uiState.test {
             val initial = awaitItem()
-            assertFalse(initial.showAddEventDialog)
-            viewModel.onShowAddEvent()
+            assertTrue(initial.currentScreen is CalendarNavScreen.Month)
+            viewModel.onShowCreateEvent()
             val afterShow = awaitItem()
-            assertTrue(afterShow.showAddEventDialog)
+            assertTrue(afterShow.currentScreen is CalendarNavScreen.CreateEvent)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun onDismissAddEvent_hidesDialogAndResetsForm() = runTest {
+    fun onDismissCreateEvent_returnsToMonthAndResetsForm() = runTest {
         val viewModel = CalendarViewModel()
         viewModel.uiState.test {
             awaitItem()
-            viewModel.onShowAddEvent()
+            viewModel.onShowCreateEvent()
             awaitItem()
-            viewModel.onNewEventTitleChange("Test")
+            viewModel.onNewEventTitleChange("Test Event")
             awaitItem()
-            viewModel.onDismissAddEvent()
+            viewModel.onDismissCreateEvent()
             val dismissed = awaitItem()
-            assertFalse(dismissed.showAddEventDialog)
+            assertTrue(dismissed.currentScreen is CalendarNavScreen.Month)
             assertEquals("", dismissed.newEventTitle)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun onShowEventDetail_navigatesToEventDetailScreen() = runTest {
+        val viewModel = CalendarViewModel()
+        viewModel.uiState.test {
+            awaitItem()
+            viewModel.onShowEventDetail("event-123")
+            val afterShow = awaitItem()
+            assertTrue(afterShow.currentScreen is CalendarNavScreen.EventDetail)
+            assertEquals("event-123", (afterShow.currentScreen as CalendarNavScreen.EventDetail).eventId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun onBackToCalendar_returnsToMonthScreen() = runTest {
+        val viewModel = CalendarViewModel()
+        viewModel.uiState.test {
+            awaitItem()
+            viewModel.onShowEventDetail("event-456")
+            awaitItem()
+            viewModel.onBackToCalendar()
+            val afterBack = awaitItem()
+            assertTrue(afterBack.currentScreen is CalendarNavScreen.Month)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -198,7 +235,7 @@ class CalendarViewModelTest {
             val countBefore = initial.events.size
             viewModel.onDaySelected(15)
             awaitItem()
-            viewModel.onShowAddEvent()
+            viewModel.onShowCreateEvent()
             awaitItem()
             viewModel.onNewEventTitleChange("Team Meeting")
             awaitItem()
@@ -213,17 +250,17 @@ class CalendarViewModelTest {
     }
 
     @Test
-    fun onAddEvent_withValidTitle_closesDialog() = runTest {
+    fun onAddEvent_withValidTitle_navigatesBackToMonth() = runTest {
         val viewModel = CalendarViewModel()
         viewModel.uiState.test {
             awaitItem()
-            viewModel.onShowAddEvent()
+            viewModel.onShowCreateEvent()
             awaitItem()
             viewModel.onNewEventTitleChange("Meeting")
             awaitItem()
             viewModel.onAddEvent()
             val afterAdd = awaitItem()
-            assertFalse(afterAdd.showAddEventDialog)
+            assertTrue(afterAdd.currentScreen is CalendarNavScreen.Month)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -234,13 +271,13 @@ class CalendarViewModelTest {
         viewModel.uiState.test {
             val initial = awaitItem()
             val countBefore = initial.events.size
-            viewModel.onShowAddEvent()
-            val dialogState = awaitItem()
-            assertTrue(dialogState.showAddEventDialog)
+            viewModel.onShowCreateEvent()
+            val createState = awaitItem()
+            assertTrue(createState.currentScreen is CalendarNavScreen.CreateEvent)
             viewModel.onAddEvent()
             expectNoEvents()
             assertEquals(countBefore, viewModel.uiState.value.events.size)
-            assertTrue(viewModel.uiState.value.showAddEventDialog)
+            assertTrue(viewModel.uiState.value.currentScreen is CalendarNavScreen.CreateEvent)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -268,7 +305,7 @@ class CalendarViewModelTest {
             val countBefore = initial.events.size
             viewModel.onDaySelected(15)
             awaitItem()
-            viewModel.onShowAddEvent()
+            viewModel.onShowCreateEvent()
             awaitItem()
             viewModel.onNewEventTitleChange("To Delete")
             awaitItem()
@@ -279,6 +316,27 @@ class CalendarViewModelTest {
             val afterDelete = awaitItem()
             assertEquals(countBefore, afterDelete.events.size)
             assertFalse(afterDelete.events.any { it.id == event.id })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun onDeleteEvent_navigatesBackToMonth() = runTest {
+        val viewModel = CalendarViewModel()
+        viewModel.uiState.test {
+            awaitItem()
+            viewModel.onShowCreateEvent()
+            awaitItem()
+            viewModel.onNewEventTitleChange("Event To Delete")
+            awaitItem()
+            viewModel.onAddEvent()
+            val afterAdd = awaitItem()
+            val event = afterAdd.events.first()
+            viewModel.onShowEventDetail(event.id)
+            awaitItem()
+            viewModel.onDeleteEvent(event.id)
+            val afterDelete = awaitItem()
+            assertTrue(afterDelete.currentScreen is CalendarNavScreen.Month)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary

- **Redesigned month calendar view** to match the reference design: prominent month/year header, Monday-first 7-column grid, taller day cells (72 dp) with coloured event-bar indicators, and a rounded bottom events panel (replacing the inline section)
- **New full-screen Create Event screen** (`CreateEventScreen.kt`) replaces the modal dialog — close × | title | Save pill button, large title field, date row, time spinners, event-type chips, notes field
- **New Event Detail screen** (`EventDetailScreen.kt`) — hero gradient header (event-type colour), stats card (duration/type/date), time detail section, notes section, delete action
- **Navigation** moved to a `CalendarNavScreen` sealed class (`Month | CreateEvent | EventDetail`) tracked in `CalendarUiState`, replacing `showAddEventDialog`
- **Monday-first calendar grid** (`Mo Tu We Th Fr Sa Su`) matching the reference; updated first-day-of-week offset calculation
- All gradients follow CLAUDE.md colour tokens throughout

## Changed files

| File | Change |
|---|---|
| `CalendarUiState.kt` | Added `CalendarNavScreen` sealed class; replaced `showAddEventDialog` with `currentScreen` |
| `CalendarViewModel.kt` | Replaced `onShowAddEvent`/`onDismissAddEvent` with `onShowCreateEvent`/`onDismissCreateEvent`/`onShowEventDetail`/`onBackToCalendar` |
| `CalendarScreen.kt` | Complete redesign: new top bar, taller Mon-first grid cells with event bars, events panel with rounded-top card |
| `CreateEventScreen.kt` | **New** — full-screen event creation |
| `EventDetailScreen.kt` | **New** — event detail with gradient hero header |
| `MainActivity.kt` | Updated to wire all new ViewModel navigation callbacks |
| `strings.xml` | Added `btn_save`, `screen_create_event`, `hint_event_title`, `label_*`, `duration_*`, `cd_close`, `cd_back`; updated `calendar_day_headers` to Monday-first |
| `CalendarViewModelTest.kt` | Replaced `showAddEventDialog` tests with `currentScreen` navigation tests; added `onShowEventDetail`, `onBackToCalendar`, `onDeleteEvent_navigatesBackToMonth` |

## Testing notes

- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — **25 tests, 0 failures, 0 errors**
- Screens verified: month view, create event, event detail, delete flow, navigation back

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/claude-code)