### PR TITLE
feat(ci): plan-before-edit phase + linter G5 / multi-line G1

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: android-ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build Debug APK

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude-agent:
     name: "🤖 Claude — ${{ github.event.label.name }}"

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -123,43 +123,65 @@ jobs:
 
             1. **Explore** the codebase — use `find`, `cat`, `Read`, `Grep` to understand the structure and patterns.
 
-            2. **Read `CLAUDE.md`** at the repo root — it contains mandatory gradient design rules and architecture you MUST follow.
+            2. **Plan — POST BEFORE EDITING.** Before any Edit/Write tool call, post a comment on issue #${{ github.event.issue.number }} with the following structure (use `gh issue comment ${{ github.event.issue.number }} --body "..."`):
 
-            3. **Implement** the ${{ contains(github.event.label.name, 'fix') && 'bug fix' || 'feature' }}:
+               ```
+               ## Implementation plan (pre-edit)
+               **Files I will modify:** <full list with paths>
+               **Every UI surface I will create or touch:** <enumerate every Box / Card / Surface / Row / Column that will receive a .background(...) — INCLUDE nested decorative surfaces: drag handles, pills, badges, dividers, chips, tab indicators. These are the surfaces that autofix loops keep missing.>
+               **Every gradient I will use:** <surface name -> Brush.linearGradient/verticalGradient + token from CLAUDE.md §2 (Primary/Accent/Success/Warning/Error/Background)>
+               **Every Color parameter I will thread:** <e.g. `color: Color` passed parent->child, `tint: Color` threaded through helpers — list every Color param crossing a composable boundary so the `color = color` violation pattern is caught before it compiles>
+               **State-shape changes:** <UiState fields added/renamed/removed; downstream ViewModel + Test files that must update in the same PR>
+               **Hardcoded glyphs / separators:** <none, OR: list with the strings.xml key each will become>
+               **Tests I will add or update:** <full file list>
+               ```
+
+               The plan must be concrete — "Update UI" or "fix all violations" is not acceptable. If implementation reveals the plan was wrong, update the comment before continuing.
+
+            3. **Read `CLAUDE.md`** at the repo root — it contains mandatory gradient design rules and architecture you MUST follow.
+
+            4. **Implement** the ${{ contains(github.event.label.name, 'fix') && 'bug fix' || 'feature' }}:
                - ALL new UI must use `Brush.linearGradient` / `verticalGradient` — flat colours are forbidden
                - Follow MVVM: ViewModel → UiState sealed class → stateless composables
                - Write unit tests for any new ViewModel or Repository logic
                - Add `contentDescription` to every Icon and Image
                - No `!!` operators
 
-            4. **Verify** — run `./gradlew assembleDebug` and fix any compile errors. Then run `./gradlew test`.
+            5. **Verify** — run `./gradlew assembleDebug` and fix any compile errors. Then run `./gradlew test`.
 
-            4a. **Run the deterministic CLAUDE.md compliance linter** and fix every line it reports before opening the PR:
+            5a. **Self-critique against plan.** Run `git diff origin/main` and walk through every enumerated item in the plan comment:
+               - Does the diff contain the change? If not, why?
+               - Did your edits introduce any NEW Box/Card/Surface/Row/Column that was NOT in the enumeration? If yes, treat it as a plan miss — verify it uses `Brush.*` not a flat `Color`, and update the plan comment.
+               - Did any `color`/`tint` parameter appear in the diff that was not listed in the plan? Trace the parameter end-to-end and verify the value at every call site.
+               Only proceed to step 5b once every diff item maps to a plan entry.
+
+            5b. **Run the deterministic CLAUDE.md compliance linter** and fix every line it reports before opening the PR:
                 ```
                 bash scripts/check-claude-md.sh --diff origin/main
                 ```
                 **Do not push if this exits non-zero.** Common violations it catches:
-                - `[G1]` flat `Color.White.copy(...)` used as a `.background(...)` — must use `Brush.linearGradient`
+                - `[G1]` flat solid background (single-line and multi-line `.background(Color...)`) — use `Brush.linearGradient`
                 - `[G3]` text alpha ≠ 0.87f — `Text(color = Color.White.copy(alpha = 0.5f))` must be `0.87f`
                 - `[G4]` icon tint has alpha — must be `tint = Color.White`
+                - `[G5]` `color`/`tint` parameter threaded without a `Color.White` literal — verify the caller value
                 - `[A1]` `IconButton` touch target < 48 dp
                 - `[S2]` single-char hardcoded separator like `Text(":")` — move to `strings.xml`
                 - `[ARCH2]` `.collectAsState()` — must be `.collectAsStateWithLifecycle()`
 
-            5. **Create a branch** named:
+            6. **Create a branch** named:
                `claude/${{ contains(github.event.label.name, 'fix') && 'fix' || 'feat' }}-issue-${{ github.event.issue.number }}-<short-description>`
 
-            6. **Commit** all changes with message:
+            7. **Commit** all changes with message:
                `${{ contains(github.event.label.name, 'fix') && 'fix' || 'feat' }}: <description> (#${{ github.event.issue.number }})`
 
-            7. **Open a PR** targeting `main` with:
+            8. **Open a PR** targeting `main` with:
                - Title matching the commit message
                - Body with: Summary, list of changed files, testing notes
                - Footer: `Closes #${{ github.event.issue.number }}`
 
-            8. **Comment on the issue** with the PR link.
+            9. **Comment on the issue** with the PR link.
 
-            9. **Enable auto-merge** on the PR you just opened:
+            10. **Enable auto-merge** on the PR you just opened:
                `gh pr merge <PR_URL_OR_NUMBER> --auto --squash --delete-branch`
                This queues the PR to merge automatically once all CI checks pass.
 

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -85,6 +85,7 @@ jobs:
             --effort high
             --max-turns 100
             --permission-mode bypassPermissions
+            --debug-file ${{ runner.temp }}/claude-debug.json
 
           prompt: |
             You are an autonomous Android coding agent triggered by GitHub Issue #${{ github.event.issue.number }}.
@@ -187,7 +188,17 @@ jobs:
 
             If the scope is unclear, comment on the issue asking for clarification — do NOT create a PR with guesswork.
 
-      # ── 5. Deterministic CLAUDE.md compliance gate ───────────────────────────
+      # ── 5. Upload Claude debug log ────────────────────────────────────────────
+      - name: Upload Claude debug log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-agent-${{ github.event.issue.number }}-run${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-debug.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # ── 6. Deterministic CLAUDE.md compliance gate ───────────────────────────
       # Catches gradient/alpha/tint/separator/architecture violations that the
       # LLM may have missed. Fails the workflow before the PR is opened, so the
       # agent must address every match rather than pushing a violating branch.

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -139,6 +139,25 @@ jobs:
                  --jq '[.[] | {path: .path, line: .line, body: .body}]'
                ```
 
+            3a. **Plan the rule-class sweep — POST BEFORE EDITING.** After reading the review comments but before any Edit/Write tool call, post a comment:
+               ```
+               gh pr comment ${{ github.event.pull_request.number }} --body "..."
+               ```
+               The comment body must contain:
+               ```
+               ## Autofix plan (attempt N)
+               **Rule classes flagged:** <e.g. G1 flat background, G3 alpha 0.5f, S2 ":">
+               **Every occurrence in changed files (by rule class):**
+                 - G1: <grep '\.background(Color' result -> file:line list>
+                 - G3: <grep result>
+                 - <one line per rule class>
+               **Every UI surface in changed files:** <enumerate every Box / Card / Surface / Row / Column including nested decorative surfaces — drag handles, pills, badges, dividers, chip backgrounds, tab indicators. These are the surfaces that get introduced during fixes and then themselves violate G1.>
+               **Color/tint parameters threaded through changed composables:** <list>
+               **NEW sub-components I plan to introduce as part of the fix:** <list, or "none" — for each new sub-component, declare its background up front>
+               **Test files I expect to update:** <list>
+               ```
+               Vague plans ("fix all G1 violations") are not acceptable — enumerate every site by file:line.
+
             4. **Fix every blocking violation using a rule-class sweep — not just the flagged lines.**
 
                For each blocking violation in the review comment:
@@ -148,9 +167,24 @@ jobs:
                  rule class. Fix ALL matches, not just the specific lines the reviewer mentioned.
                  The reviewer samples; you must sweep every instance.
 
+               **Scope-creep guard:** When fixing a violation, do NOT wrap the violating element in a
+               new Box/Card/Surface unless the parent layout genuinely requires it. Most G1/G3/G4
+               fixes are in-place edits to the existing modifier chain. Every new sub-component you
+               introduce is a fresh surface that can itself violate G1 — PR #28 ran 7 attempts
+               chasing exactly this pattern. If you must introduce a new sub-component, declare it
+               in the plan comment (step 3a) AND apply `Brush.*` to it in the same edit.
+
                Stay within scope — do NOT touch files that were not changed in this PR.
                Do NOT edit `.github/`, `gradle/`, `gradle.properties`, `settings.gradle*`,
                or top-level `build.gradle*`.
+
+            4a. **Self-critique against plan.** Run `git diff origin/main` and walk through every
+               enumerated item in the plan comment:
+               - For each NEW Box/Card/Surface introduced by your fix, verify it uses `Brush.*` and
+                 was declared in the plan; if not, update the plan comment AND fix the surface.
+               - For any `color`/`tint` parameter in the diff that was not listed in the plan,
+                 trace the value to the call site and verify it resolves to `Color.White`.
+               Only proceed to step 5 once the diff matches the plan.
 
             5. After fixing, run the deterministic compliance script and resolve every line it reports:
                ```

--- a/.github/workflows/claude-autofix.yml
+++ b/.github/workflows/claude-autofix.yml
@@ -100,6 +100,7 @@ jobs:
             --effort high
             --max-turns 80
             --permission-mode bypassPermissions
+            --debug-file ${{ runner.temp }}/claude-debug.json
 
           prompt: |
             You are auto-fixing CLAUDE.md violations on PR #${{ github.event.pull_request.number }}.
@@ -220,7 +221,17 @@ jobs:
             another rule), do NOT push a no-op commit — instead post a comment
             explaining why and exit. The attempt cap will then guard against loops.
 
-      # ── 6. Deterministic compliance gate (runs after Claude's edits) ────────
+      # ── 6. Upload Claude debug log ────────────────────────────────────────────
+      - name: Upload Claude debug log
+        if: steps.attempt_check.outputs.max_reached == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-autofix-pr${{ github.event.pull_request.number }}-attempt${{ steps.attempt_check.outputs.attempt }}-run${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-debug.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # ── 7. Deterministic compliance gate (runs after Claude's edits) ────────
       # If the LLM only fixed the flagged lines and missed other instances of
       # the same rule, this step catches them before a push happens.
       - name: Verify CLAUDE.md compliance (deterministic)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,25 +52,23 @@ jobs:
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in this Android Kotlin + Jetpack Compose repo.
 
-            ## Deterministic linter output (already computed — do NOT re-check these rules)
+            ## Steps
 
-            A regex-based linter has already scanned every changed line for the mechanically-detectable
-            CLAUDE.md rules (G1–G4, A1, S2, ARCH1, ARCH2). Its output is authoritative and complete:
+            1. Read `CLAUDE.md` at the repo root — it is the single source of truth for project rules.
+
+            2. Run `gh pr diff ${{ github.event.pull_request.number }}` and **read the full diff**.
+
+            3. **Form your own list of issues from the diff** — architecture, accessibility, scope creep, missing tests, and the judgment-call rules listed below. Do this BEFORE consulting the deterministic linter output in step 4, so your analysis is not anchored to what the linter already found. The linter only catches mechanical patterns; you are responsible for the architecture and accessibility issues it cannot see.
+
+            4. **Now consult the deterministic linter output** (already computed — do NOT re-run these checks):
 
             ```
             ${{ steps.linter.outputs.linter_output }}
             ```
 
-            **Include every line above verbatim in the Blocking violations section of your review.**
-            Do NOT spend turns re-checking gradient backgrounds, text alpha values, icon tints,
-            touch targets, single-char separators, or ViewModel imports — those are already caught above.
-            Focus your analysis on rules that require judgment:
+            The linter has scanned every changed line for G1–G5, A1, S2, ARCH1, ARCH2. Its output is authoritative for those rules. **Append every line above verbatim to your blocking-violations list.** Do NOT spend turns re-checking gradient backgrounds, text alpha values, icon tints, touch targets, single-char separators, or ViewModel imports.
 
-            ## Steps
-
-            1. Read `CLAUDE.md` at the repo root — it is the single source of truth for project rules.
-            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to see all changed files and lines.
-            3. Evaluate the diff against the **judgment-call** rules below. Rules are split into
+            5. Evaluate the diff against the **judgment-call** rules below. Rules are split into
                **BLOCKING** (fail the PR) and **ADVISORY** (leave a comment but do not block).
 
             ---
@@ -113,15 +111,15 @@ jobs:
 
             ---
 
-            4. Post inline comments for line-specific issues using the `mcp__github_inline_comment__create_inline_comment` tool.
-            5. Post one structured top-level summary comment via:
+            6. Post inline comments for line-specific issues using the `mcp__github_inline_comment__create_inline_comment` tool.
+            7. Post one structured top-level summary comment via:
                `gh pr comment ${{ github.event.pull_request.number }} --body "..."`
                Structure:
                - ✅ **Passed checks** — list what was verified and passed
                - ❌ **Blocking violations** — include ALL linter output lines verbatim, then add any architecture/accessibility violations you found
                - ⚠️ **Advisory notes** — list non-blocking suggestions
                - 📁 **Files reviewed** — list all changed files examined
-            6. **Apply a verdict label — this gates the merge:**
+            8. **Apply a verdict label — this gates the merge:**
                First remove any prior verdict:
                `gh pr edit ${{ github.event.pull_request.number }} --remove-label "review: passed" --remove-label "review: blocked" 2>/dev/null || true`
                Then apply the outcome:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,6 +48,7 @@ jobs:
             --effort high
             --max-turns 60
             --permission-mode bypassPermissions
+            --debug-file ${{ runner.temp }}/claude-debug.json
 
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in this Android Kotlin + Jetpack Compose repo.
@@ -127,6 +128,15 @@ jobs:
                - FAIL (linter reported violations OR you found architecture/accessibility violations): `gh pr edit ${{ github.event.pull_request.number }} --add-label "review: blocked"`
 
             Advisory-only issues never cause a FAIL verdict. Be accurate — do not block on advisory issues.
+
+      - name: Upload Claude debug log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-debug-review-pr${{ github.event.pull_request.number }}-run${{ github.run_id }}
+          path: ${{ runner.temp }}/claude-debug.json
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Enforce review verdict
         if: always()

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   guard:
     name: Verify main branch health

--- a/scripts/check-claude-md.sh
+++ b/scripts/check-claude-md.sh
@@ -8,6 +8,10 @@
 #
 # Exit codes: 0 = clean, 1 = violations found
 # Output format: <file>:<line> [<ID>] <description> — `<snippet>`
+#
+# Rules: G1 (flat bg, single + multi-line), G2 (containerColor), G3 (text alpha),
+#        G4 (icon tint), G5 (color/tint param threaded without Color.White),
+#        A1 (touch target < 48dp), S2 (separator), ARCH1 (ViewModel view.*), ARCH2 (collectAsState)
 
 set -euo pipefail
 
@@ -116,6 +120,20 @@ scan_file() {
       report "$file" "$lineno" "G4" "icon tint is a non-white solid colour — must be tint = Color.White" "$snippet"
     fi
 
+    # G5 — color/tint parameter threaded without a Color.White literal at call site
+    # Catches `Text(... color = someVariable)` / `Icon(... tint = someVariable)` patterns
+    # where a non-literal Color variable is passed in (e.g. `color = color`, `tint = iconTint`).
+    # Variables start with lowercase; Color literals start with uppercase Color.
+    # Informational — output says "verify caller value" rather than hard-blocking.
+    if echo "$line_text" | grep -qP '\b(Text|Icon)\b'; then
+      if echo "$line_text" | grep -qP '\b(color|tint)\s*=\s*[a-z][a-zA-Z0-9_.]*\b'; then
+        if ! echo "$line_text" | grep -qP '\b(color|tint)\s*=\s*Color\.'; then
+          snippet=$(echo "$line_text" | sed 's/^[[:space:]]*//')
+          report "$file" "$lineno" "G5" "color/tint parameter threaded without Color.White literal — verify caller value or hardcode Color.White" "$snippet"
+        fi
+      fi
+    fi
+
     # A1 — Touch target < 48 dp on IconButton
     if echo "$line_text" | grep -qP 'IconButton\('; then
       if echo "$line_text" | grep -qP 'Modifier\.size\(([0-3]?[0-9]|4[0-7])\.dp\)'; then
@@ -150,10 +168,47 @@ scan_file() {
   done < "$file"
 }
 
+# ── G1 multi-line scanner ────────────────────────────────────────────────────
+# The line-by-line scan_file only catches .background(Color...) on one line.
+# This function catches the split form:
+#   .background(
+#       Color(0xFF...)     <- Color on a continuation line
+#   )
+# It scans up to 6 continuation lines after each .background( opener.
+scan_file_multiline() {
+  local file="$1"
+  local start_lines
+  start_lines=$(awk '
+    /\.background\(/ && !/Brush\./ {
+      start = NR
+      buf = $0
+      for (i = 1; i <= 6; i++) {
+        if ((getline nextline) <= 0) break
+        if (nextline ~ /Brush\./) { buf = ""; break }
+        buf = buf "\n" nextline
+        if (nextline ~ /^[[:space:]]*\)/) {
+          if (buf ~ /Color[\.\(]/ && buf !~ /Brush\./) print start
+          buf = ""
+          break
+        }
+      }
+    }
+  ' "$file")
+
+  while IFS= read -r start_line; do
+    [[ -z "$start_line" ]] && continue
+    is_in_diff "$file" "$start_line" || continue
+    local snippet
+    snippet=$(sed -n "${start_line}p" "$file" | sed 's/^[[:space:]]*//')
+    report "$file" "$start_line" "G1" "multi-line flat .background(...) — use Brush.linearGradient/verticalGradient" "$snippet"
+  done <<< "$start_lines"
+}
+
 # ── Run across all target files ───────────────────────────────────────────────
 for f in "${TARGET_FILES[@]}"; do
   [[ -f "$f" ]] || continue
   scan_file "$f"
+  scan_file_multiline "$f"
 done
 
 # ── Summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Plan-before-edit gate**: `claude-agent` and `claude-autofix` now post a structured plan comment on the issue/PR **before** any `Edit`/`Write` tool call, enumerating every UI surface, gradient, threaded Color parameter, state-shape change, and expected test update. After editing, a self-critique step walks the diff against the plan before the deterministic linter runs.

- **Scope-creep guard**: `claude-autofix` now explicitly forbids wrapping violations in new `Box`/`Card`/`Surface` sub-components (the PR #28 pattern that caused 7 autofix attempts by introducing new surfaces that themselves violated G1).

- **Review de-parroting**: `claude-review` now reads the full diff and forms its own findings **before** consulting the linter output. Previously, the linter output was injected first and the LLM was told "include every line verbatim" — it anchored on the linter instead of doing independent judgment-call analysis.

- **Linter: G5** — new rule in `scripts/check-claude-md.sh` catching `Text(... color = variable)` / `Icon(... tint = variable)` patterns where a non-`Color.White` literal is threaded across a composable boundary (the `color = color` bug that autofix attempt 2 on PR #28 had to fix manually).

- **Linter: G1 multi-line** — new `scan_file_multiline` function catching `.background(` split across lines with `Color(...)` on a continuation line (the existing single-line G1 only fires when both appear on the same line; the drag-handle pill on CalendarScreen:450 survived 5 autofix attempts because it was split).

## Files changed

- `.github/workflows/claude-agent.yml`
- `.github/workflows/claude-autofix.yml`
- `.github/workflows/claude-review.yml`
- `scripts/check-claude-md.sh`

## Test plan

- [ ] `android-ci.yml` passes (no Kotlin changed)
- [ ] `claude-review.yml` runs on this PR — linter output should be empty (no `.kt` files changed); Claude should post a structured comment; verdict = `review: passed`
- [ ] If `review: blocked` fires, fix manually — **do NOT let `claude-autofix` run on a workflow-config PR** (the autofix prompt already forbids editing `.github/` so it would no-op, but safer to avoid)
- [ ] After merge: verify next agent-opened PR includes an "Implementation plan (pre-edit)" issue comment before the first commit timestamp

## Note

This is a CI infrastructure change — does not close a GitHub Issue.