### PR TITLE
feat: implement Calenderly redesign with 22 screens and onboarding flow (#30)

### DIFF
--- a/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
@@ -24,17 +24,15 @@ class MainActivity : ComponentActivity() {
 
                 when (val screen = appState.value.currentScreen) {
                     is AppScreen.Splash -> {
-                        val context = this
                         SplashScreen(
-                            onSplashDone = { appViewModel.onSplashComplete(context) }
+                            onSplashDone = { appViewModel.onSplashComplete() }
                         )
                     }
                     is AppScreen.Onboarding -> {
-                        val context = this
                         OnboardingScreen(
                             step = appState.value.onboardingStep,
                             onNext = appViewModel::onOnboardingNext,
-                            onGetStarted = { appViewModel.onOnboardingComplete(context) }
+                            onGetStarted = { appViewModel.onOnboardingComplete() }
                         )
                     }
                     is AppScreen.Main -> {

--- a/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/MainActivity.kt
@@ -6,8 +6,11 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.testingapplictionandriod.ui.calendar.CalendarScreen
-import com.example.testingapplictionandriod.ui.calendar.CalendarViewModel
+import com.example.testingapplictionandriod.ui.app.AppScreen
+import com.example.testingapplictionandriod.ui.app.AppViewModel
+import com.example.testingapplictionandriod.ui.main.MainScreen
+import com.example.testingapplictionandriod.ui.onboarding.OnboardingScreen
+import com.example.testingapplictionandriod.ui.splash.SplashScreen
 import com.example.testingapplictionandriod.ui.theme.TestingapplictionandriodTheme
 
 class MainActivity : ComponentActivity() {
@@ -16,28 +19,28 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TestingapplictionandriodTheme {
-                val viewModel: CalendarViewModel = viewModel()
-                val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-                CalendarScreen(
-                    uiState = uiState.value,
-                    onPreviousMonth = viewModel::onPreviousMonth,
-                    onNextMonth = viewModel::onNextMonth,
-                    onGoToToday = viewModel::onGoToToday,
-                    onDaySelected = viewModel::onDaySelected,
-                    onShowCreateEvent = viewModel::onShowCreateEvent,
-                    onDismissCreateEvent = viewModel::onDismissCreateEvent,
-                    onNewEventTitleChange = viewModel::onNewEventTitleChange,
-                    onNewEventDescriptionChange = viewModel::onNewEventDescriptionChange,
-                    onNewEventTypeChange = viewModel::onNewEventTypeChange,
-                    onNewEventStartHourChange = viewModel::onNewEventStartHourChange,
-                    onNewEventStartMinuteChange = viewModel::onNewEventStartMinuteChange,
-                    onNewEventEndHourChange = viewModel::onNewEventEndHourChange,
-                    onNewEventEndMinuteChange = viewModel::onNewEventEndMinuteChange,
-                    onAddEvent = viewModel::onAddEvent,
-                    onDeleteEvent = viewModel::onDeleteEvent,
-                    onShowEventDetail = viewModel::onShowEventDetail,
-                    onBackToCalendar = viewModel::onBackToCalendar
-                )
+                val appViewModel: AppViewModel = viewModel()
+                val appState = appViewModel.uiState.collectAsStateWithLifecycle()
+
+                when (val screen = appState.value.currentScreen) {
+                    is AppScreen.Splash -> {
+                        val context = this
+                        SplashScreen(
+                            onSplashDone = { appViewModel.onSplashComplete(context) }
+                        )
+                    }
+                    is AppScreen.Onboarding -> {
+                        val context = this
+                        OnboardingScreen(
+                            step = appState.value.onboardingStep,
+                            onNext = appViewModel::onOnboardingNext,
+                            onGetStarted = { appViewModel.onOnboardingComplete(context) }
+                        )
+                    }
+                    is AppScreen.Main -> {
+                        MainScreen(appViewModel = appViewModel)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/testingapplictionandriod/domain/model/Note.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/domain/model/Note.kt
@@ -1,0 +1,14 @@
+package com.example.testingapplictionandriod.domain.model
+
+import java.util.UUID
+
+data class Note(
+    val id: String = UUID.randomUUID().toString(),
+    val title: String,
+    val content: String = "",
+    val tag: String = "",
+    val colorIndex: Int = 0,
+    val createdYear: Int,
+    val createdMonth: Int,
+    val createdDay: Int
+)

--- a/app/src/main/java/com/example/testingapplictionandriod/domain/model/Task.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/domain/model/Task.kt
@@ -1,0 +1,18 @@
+package com.example.testingapplictionandriod.domain.model
+
+import java.util.UUID
+
+data class Task(
+    val id: String = UUID.randomUUID().toString(),
+    val title: String,
+    val notes: String = "",
+    val priority: TaskPriority = TaskPriority.NONE,
+    val dueYear: Int? = null,
+    val dueMonth: Int? = null,
+    val dueDay: Int? = null,
+    val dueHour: Int? = null,
+    val dueMinute: Int? = null,
+    val isCompleted: Boolean = false
+)
+
+enum class TaskPriority { HIGH, MEDIUM, LOW, NONE }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppUiState.kt
@@ -1,0 +1,15 @@
+package com.example.testingapplictionandriod.ui.app
+
+sealed interface AppScreen {
+    data object Splash : AppScreen
+    data object Onboarding : AppScreen
+    data object Main : AppScreen
+}
+
+data class AppUiState(
+    val currentScreen: AppScreen = AppScreen.Splash,
+    val onboardingStep: Int = 0,
+    val selectedTab: MainTab = MainTab.CALENDAR
+)
+
+enum class MainTab { CALENDAR, TASKS, NOTES, MINE }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppViewModel.kt
@@ -1,7 +1,8 @@
 package com.example.testingapplictionandriod.ui.app
 
+import android.app.Application
 import android.content.Context
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,13 +11,13 @@ import kotlinx.coroutines.flow.update
 private const val PREFS_NAME = "calenderly_prefs"
 private const val KEY_ONBOARDING_DONE = "onboarding_done"
 
-class AppViewModel : ViewModel() {
+class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     private val _uiState = MutableStateFlow(AppUiState())
     val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
 
-    fun onSplashComplete(context: Context) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    fun onSplashComplete() {
+        val prefs = getApplication<Application>().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val onboardingDone = prefs.getBoolean(KEY_ONBOARDING_DONE, false)
         _uiState.update {
             it.copy(currentScreen = if (onboardingDone) AppScreen.Main else AppScreen.Onboarding)
@@ -30,8 +31,8 @@ class AppViewModel : ViewModel() {
         }
     }
 
-    fun onOnboardingComplete(context: Context) {
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    fun onOnboardingComplete() {
+        getApplication<Application>().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit().putBoolean(KEY_ONBOARDING_DONE, true).apply()
         _uiState.update { it.copy(currentScreen = AppScreen.Main) }
     }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/app/AppViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.testingapplictionandriod.ui.app
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+private const val PREFS_NAME = "calenderly_prefs"
+private const val KEY_ONBOARDING_DONE = "onboarding_done"
+
+class AppViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AppUiState())
+    val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
+
+    fun onSplashComplete(context: Context) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val onboardingDone = prefs.getBoolean(KEY_ONBOARDING_DONE, false)
+        _uiState.update {
+            it.copy(currentScreen = if (onboardingDone) AppScreen.Main else AppScreen.Onboarding)
+        }
+    }
+
+    fun onOnboardingNext() {
+        val step = _uiState.value.onboardingStep
+        if (step < 1) {
+            _uiState.update { it.copy(onboardingStep = step + 1) }
+        }
+    }
+
+    fun onOnboardingComplete(context: Context) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_ONBOARDING_DONE, true).apply()
+        _uiState.update { it.copy(currentScreen = AppScreen.Main) }
+    }
+
+    fun onTabSelected(tab: MainTab) {
+        _uiState.update { it.copy(selectedTab = tab) }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,37 +13,51 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringArrayResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.testingapplictionandriod.R
 import com.example.testingapplictionandriod.domain.model.CalendarEvent
 import com.example.testingapplictionandriod.domain.model.EventType
-import java.text.SimpleDateFormat
+import com.example.testingapplictionandriod.ui.components.CalenderlyFab
+import com.example.testingapplictionandriod.ui.components.UpgradeBanner
+import java.util.Calendar
 import java.util.Locale
+
+// Calenderly design tokens
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CDangerRed = Color(0xFFDE3030)
+private val CInk = Color(0xFF1A1A2E)
+private val CInk3 = Color(0xFF3D3D5C)
+private val CMuted = Color(0xFF8B8BA7)
+private val CMuted2 = Color(0xFFC8C8D8)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+private val CCoralColor = Color(0xFFE85C4A)
+private val CSuccessColor = Color(0xFF22C55E)
+private val CWarnColor = Color(0xFFF97316)
+
+private val MONTH_NAMES = listOf(
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+)
 
 @Composable
 fun CalendarScreen(
@@ -65,10 +78,13 @@ fun CalendarScreen(
     onAddEvent: () -> Unit,
     onDeleteEvent: (String) -> Unit,
     onShowEventDetail: (String) -> Unit,
-    onBackToCalendar: () -> Unit
+    onBackToCalendar: () -> Unit,
+    onShowDayView: () -> Unit = {},
+    onShowWeekView: () -> Unit = {},
+    onToggleNotifications: () -> Unit = {}
 ) {
-    when (val screen = uiState.currentScreen) {
-        CalendarNavScreen.Month -> CalendarMonthView(
+    when (uiState.currentScreen) {
+        is CalendarNavScreen.Month -> CalendarMonthScreen(
             uiState = uiState,
             onPreviousMonth = onPreviousMonth,
             onNextMonth = onNextMonth,
@@ -76,9 +92,11 @@ fun CalendarScreen(
             onDaySelected = onDaySelected,
             onShowCreateEvent = onShowCreateEvent,
             onShowEventDetail = onShowEventDetail,
-            onDeleteEvent = onDeleteEvent
+            onShowWeekView = onShowWeekView,
+            onShowDayView = onShowDayView,
+            onToggleNotifications = onToggleNotifications
         )
-        CalendarNavScreen.CreateEvent -> CreateEventScreen(
+        is CalendarNavScreen.CreateEvent -> CreateEventScreen(
             uiState = uiState,
             onDismiss = onDismissCreateEvent,
             onTitleChange = onNewEventTitleChange,
@@ -91,24 +109,32 @@ fun CalendarScreen(
             onSave = onAddEvent
         )
         is CalendarNavScreen.EventDetail -> {
-            val event = uiState.events.find { it.id == screen.eventId }
+            val eventId = (uiState.currentScreen as CalendarNavScreen.EventDetail).eventId
+            val event = uiState.events.find { it.id == eventId }
             if (event != null) {
                 EventDetailScreen(
                     event = event,
                     onBack = onBackToCalendar,
-                    onDelete = { onDeleteEvent(event.id) }
+                    onDelete = { onDeleteEvent(eventId) }
                 )
             } else {
-                LaunchedEffect(screen.eventId) { onBackToCalendar() }
+                onBackToCalendar()
             }
         }
+        is CalendarNavScreen.DayView -> DayViewScreen(
+            uiState = uiState,
+            onBack = onBackToCalendar,
+            onShowCreateEvent = onShowCreateEvent
+        )
+        is CalendarNavScreen.WeekView -> WeekViewScreen(
+            uiState = uiState,
+            onBack = onBackToCalendar
+        )
     }
 }
 
-// ── Month view ────────────────────────────────────────────────
-
 @Composable
-private fun CalendarMonthView(
+private fun CalendarMonthScreen(
     uiState: CalendarUiState,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
@@ -116,392 +142,307 @@ private fun CalendarMonthView(
     onDaySelected: (Int) -> Unit,
     onShowCreateEvent: () -> Unit,
     onShowEventDetail: (String) -> Unit,
-    onDeleteEvent: (String) -> Unit
+    onShowWeekView: () -> Unit,
+    onShowDayView: () -> Unit,
+    onToggleNotifications: () -> Unit
 ) {
+    val today = remember { Calendar.getInstance() }
+    val todayYear = today.get(Calendar.YEAR)
+    val todayMonth = today.get(Calendar.MONTH) + 1
+    val todayDay = today.get(Calendar.DAY_OF_MONTH)
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
-                )
-            )
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             CalendarTopBar(
-                year = uiState.displayedYear,
-                month = uiState.displayedMonth,
-                onPreviousMonth = onPreviousMonth,
-                onNextMonth = onNextMonth,
-                onGoToToday = onGoToToday
+                month = "${MONTH_NAMES[uiState.displayedMonth - 1]} ${uiState.displayedYear}",
+                onSearch = {},
+                onBell = onToggleNotifications,
+                onToggleView = onShowWeekView
             )
-
-            WeekdayHeaders()
-
-            CalendarGrid(
+            WeekdayHeader()
+            MonthGrid(
                 year = uiState.displayedYear,
                 month = uiState.displayedMonth,
                 selectedDay = uiState.selectedDay,
+                todayYear = todayYear,
+                todayMonth = todayMonth,
+                todayDay = todayDay,
                 events = uiState.events,
-                onDaySelected = onDaySelected
+                onDayTap = { day ->
+                    onDaySelected(day)
+                }
             )
-
-            EventsPanel(
-                modifier = Modifier.weight(1f),
-                year = uiState.displayedYear,
-                month = uiState.displayedMonth,
-                selectedDay = uiState.selectedDay,
-                events = uiState.events,
-                onShowEventDetail = onShowEventDetail,
-                onDeleteEvent = onDeleteEvent
-            )
+            Spacer(Modifier.weight(1f))
+            UpgradeBanner()
         }
 
-        // FAB — rounded square, gradient
-        Box(
+        CalenderlyFab(
+            onClick = onShowCreateEvent,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(end = 20.dp, bottom = 20.dp)
-                .size(56.dp)
-                .background(
-                    Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))),
-                    RoundedCornerShape(16.dp)
+                .padding(end = 20.dp, bottom = 144.dp)
+        )
+
+        if (uiState.selectedDay != null && uiState.selectedDay > 0) {
+            val dayEvents = uiState.events.filter { e ->
+                e.year == uiState.displayedYear &&
+                        e.month == uiState.displayedMonth &&
+                        e.day == uiState.selectedDay
+            }
+            if (dayEvents.isNotEmpty()) {
+                DayEventSheet(
+                    events = dayEvents,
+                    onEventTap = onShowEventDetail,
+                    onDismiss = { onDaySelected(0) }
                 )
-                .clip(RoundedCornerShape(16.dp))
-                .clickable(onClick = onShowCreateEvent),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Add,
-                contentDescription = stringResource(R.string.cd_add_event),
-                tint = Color.White,
-                modifier = Modifier.size(28.dp)
-            )
+            }
         }
     }
 }
-
-// ── Top bar ───────────────────────────────────────────────────
 
 @Composable
 private fun CalendarTopBar(
-    year: Int,
-    month: Int,
-    onPreviousMonth: () -> Unit,
-    onNextMonth: () -> Unit,
-    onGoToToday: () -> Unit
+    month: String,
+    onSearch: () -> Unit,
+    onBell: () -> Unit,
+    onToggleView: () -> Unit
 ) {
-    val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, 1) }
-    val monthName = SimpleDateFormat(stringResource(R.string.date_format_month_only), Locale.getDefault()).format(cal.time)
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 20.dp, end = 8.dp, top = 16.dp, bottom = 8.dp),
+            .height(56.dp)
+            .background(Brush.verticalGradient(listOf(Color.White, Color(0xFFFDFDFF))))
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = monthName,
-                color = Color.White,
-                fontWeight = FontWeight.Bold,
-                fontSize = 28.sp,
-                lineHeight = 30.sp
-            )
-            Text(
-                text = year.toString(),
-                color = Color.White.copy(alpha = 0.87f),
-                fontWeight = FontWeight.Medium,
-                fontSize = 14.sp
-            )
-        }
-
-        Box(
-            modifier = Modifier
-                .background(
-                    Brush.linearGradient(
-                        listOf(Color(0xFF6366F1).copy(alpha = 0.35f), Color(0xFF8B5CF6).copy(alpha = 0.35f))
-                    ),
-                    RoundedCornerShape(20.dp)
-                )
-                .clickable(onClick = onGoToToday)
-                .padding(horizontal = 14.dp, vertical = 8.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.btn_today),
-                color = Color.White,
-                fontSize = 13.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-        }
-
-        IconButton(onClick = onPreviousMonth) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                contentDescription = stringResource(R.string.cd_previous_month),
-                tint = Color.White
-            )
-        }
-
-        IconButton(onClick = onNextMonth) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = stringResource(R.string.cd_next_month),
-                tint = Color.White
-            )
-        }
-    }
-}
-
-// ── Weekday headers ───────────────────────────────────────────
-
-@Composable
-private fun WeekdayHeaders() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp)
-    ) {
-        stringArrayResource(R.array.calendar_day_headers).forEach { label ->
-            Text(
-                text = label,
-                modifier = Modifier.weight(1f),
-                textAlign = TextAlign.Center,
-                color = Color.White.copy(alpha = 0.87f),
-                fontSize = 11.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 1.sp
-            )
-        }
-    }
-}
-
-// ── Calendar grid ─────────────────────────────────────────────
-
-@Composable
-private fun CalendarGrid(
-    year: Int,
-    month: Int,
-    selectedDay: Int?,
-    events: List<CalendarEvent>,
-    onDaySelected: (Int) -> Unit
-) {
-    val today = java.util.Calendar.getInstance()
-    val todayYear = today.get(java.util.Calendar.YEAR)
-    val todayMonth = today.get(java.util.Calendar.MONTH) + 1
-    val todayDay = today.get(java.util.Calendar.DAY_OF_MONTH)
-
-    val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, 1) }
-    val daysInMonth = cal.getActualMaximum(java.util.Calendar.DAY_OF_MONTH)
-    // Monday-first offset: Mon=0, Tue=1, …, Sun=6
-    val firstDayOfWeek = (cal.get(java.util.Calendar.DAY_OF_WEEK) - java.util.Calendar.MONDAY + 7) % 7
-
-    val cells = List(firstDayOfWeek) { 0 } + (1..daysInMonth).toList()
-    val remainder = cells.size % 7
-    val paddedCells = if (remainder == 0) cells else cells + List(7 - remainder) { 0 }
-
-    Column(modifier = Modifier.padding(horizontal = 6.dp)) {
-        paddedCells.chunked(7).forEach { week ->
-            Row(modifier = Modifier.fillMaxWidth()) {
-                week.forEach { day ->
-                    CalendarDayCell(
-                        day = day,
-                        isToday = day != 0 && year == todayYear && month == todayMonth && day == todayDay,
-                        isSelected = day != 0 && day == selectedDay,
-                        dayEvents = if (day != 0) events.filter {
-                            it.year == year && it.month == month && it.day == day
-                        } else emptyList(),
-                        onClick = { if (day != 0) onDaySelected(day) },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun CalendarDayCell(
-    day: Int,
-    isToday: Boolean,
-    isSelected: Boolean,
-    dayEvents: List<CalendarEvent>,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .height(72.dp)
-            .padding(2.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        if (day != 0) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .then(
-                        when {
-                            isSelected -> Modifier.background(
-                                Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6))),
-                                RoundedCornerShape(14.dp)
-                            )
-                            isToday -> Modifier.background(
-                                Brush.linearGradient(listOf(Color(0xFF06B6D4), Color(0xFF3B82F6))),
-                                RoundedCornerShape(14.dp)
-                            )
-                            else -> Modifier.background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFF6366F1).copy(alpha = 0.04f), Color(0xFF8B5CF6).copy(alpha = 0.04f))
-                                ),
-                                RoundedCornerShape(14.dp)
-                            )
-                        }
-                    )
-                    .clip(RoundedCornerShape(14.dp))
-                    .clickable(onClick = onClick)
-                    .padding(top = 8.dp, start = 4.dp, end = 4.dp, bottom = 4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = day.toString(),
-                    color = if (isSelected || isToday) Color.White else Color.White.copy(alpha = 0.87f),
-                    fontSize = 14.sp,
-                    fontWeight = if (isSelected || isToday) FontWeight.Bold else FontWeight.Medium,
-                    textAlign = TextAlign.Center
-                )
-
-                if (dayEvents.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 3.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp)
-                    ) {
-                        dayEvents.take(3).forEach { event ->
-                            val (sc, ec) = event.type.gradientColors()
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(4.dp)
-                                    .background(
-                                        if (isSelected || isToday)
-                                            Brush.linearGradient(
-                                                listOf(Color.White.copy(alpha = 0.75f), Color.White)
-                                            )
-                                        else
-                                            Brush.linearGradient(listOf(sc, ec)),
-                                        RoundedCornerShape(2.dp)
-                                    )
-                            )
-                        }
-                        if (dayEvents.size > 3) {
-                            Text(
-                                text = stringResource(R.string.events_overflow_count, dayEvents.size - 3),
-                                color = if (isSelected || isToday) Color.White
-                                        else Color.White.copy(alpha = 0.87f),
-                                fontSize = 8.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-// ── Events panel (bottom sheet style) ────────────────────────
-
-@Composable
-private fun EventsPanel(
-    modifier: Modifier = Modifier,
-    year: Int,
-    month: Int,
-    selectedDay: Int?,
-    events: List<CalendarEvent>,
-    onShowEventDetail: (String) -> Unit,
-    onDeleteEvent: (String) -> Unit
-) {
-    val selectedEvents = if (selectedDay != null) {
-        events.filter { it.year == year && it.month == month && it.day == selectedDay }
-            .sortedWith(compareBy({ it.startHour }, { it.startMinute }))
-    } else emptyList()
-
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(
-                Brush.linearGradient(listOf(Color(0xFF1A1741), Color(0xFF2D2A5E))),
-                RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
-            )
-    ) {
-        // Drag handle
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 10.dp, bottom = 6.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Box(
-                modifier = Modifier
-                    .width(36.dp)
-                    .height(4.dp)
-                    .background(
-                        Brush.linearGradient(
-                            listOf(Color.White.copy(alpha = 0.15f), Color.White.copy(alpha = 0.28f))
-                        ),
-                        RoundedCornerShape(2.dp)
-                    )
-            )
-        }
-
-        // Day header row
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 18.dp, vertical = 6.dp),
+                .weight(1f)
+                .clickable(onClick = onToggleView),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = if (selectedDay != null) {
-                    val cal = java.util.Calendar.getInstance().apply { set(year, month - 1, selectedDay) }
-                    SimpleDateFormat(stringResource(R.string.date_format_day_month), Locale.getDefault()).format(cal.time)
-                } else {
-                    stringResource(R.string.events_title_no_selection)
-                },
-                color = Color.White,
+                text = month,
+                fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
-                fontSize = 17.sp,
-                modifier = Modifier.weight(1f)
+                color = CInk,
+                letterSpacing = (-0.3).sp
             )
-            if (selectedDay != null && selectedEvents.isNotEmpty()) {
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                imageVector = Icons.Filled.ChevronRight,
+                contentDescription = "Toggle calendar view",
+                tint = CMuted,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        Row(
+            modifier = Modifier
+                .background(CSurface, RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onToggleView)
+                .padding(horizontal = 10.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.GridView,
+                contentDescription = "Switch view",
+                tint = CInk3,
+                modifier = Modifier.size(16.dp)
+            )
+            Text(text = "Month", fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = CInk)
+        }
+        Spacer(Modifier.width(4.dp))
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onSearch),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Search,
+                contentDescription = "Search events",
+                tint = CInk,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onBell),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Notifications,
+                contentDescription = "Notifications",
+                tint = CInk,
+                modifier = Modifier.size(22.dp)
+            )
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(CDangerRed, CircleShape)
+                    .align(Alignment.TopEnd)
+            )
+        }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(Brush.verticalGradient(listOf(CHair, CHair)))
+    )
+}
+
+@Composable
+private fun WeekdayHeader() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(32.dp)
+            .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+    ) {
+        listOf("S", "M", "T", "W", "T", "F", "S").forEachIndexed { i, day ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
                 Text(
-                    text = pluralStringResource(R.plurals.events_count, selectedEvents.size, selectedEvents.size),
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 13.sp
+                    text = day,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (i == 0 || i == 6) CMuted else CInk3,
+                    letterSpacing = 0.3.sp
                 )
             }
         }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(Brush.verticalGradient(listOf(CHair, CHair)))
+    )
+}
 
-        Spacer(modifier = Modifier.height(4.dp))
+@Composable
+private fun MonthGrid(
+    year: Int,
+    month: Int,
+    selectedDay: Int?,
+    todayYear: Int,
+    todayMonth: Int,
+    todayDay: Int,
+    events: List<CalendarEvent>,
+    onDayTap: (Int) -> Unit
+) {
+    val cells = remember(year, month) { buildMonthCells(year, month) }
+    val eventsThisMonth = remember(events, year, month) {
+        events.filter { it.year == year && it.month == month }
+    }
 
-        when {
-            selectedDay == null -> PanelEmptyState(stringResource(R.string.events_tap_to_select))
-            selectedEvents.isEmpty() -> PanelEmptyState(stringResource(R.string.events_no_events))
-            else -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    contentPadding = PaddingValues(
-                        start = 16.dp, end = 16.dp, bottom = 88.dp
-                    )
-                ) {
-                    items(selectedEvents, key = { it.id }) { event ->
-                        EventPanelCard(
-                            event = event,
-                            onTap = { onShowEventDetail(event.id) },
-                            onDelete = { onDeleteEvent(event.id) }
+    Column {
+        cells.chunked(7).forEach { week ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(88.dp)
+            ) {
+                week.forEachIndexed { ci, cell ->
+                    val isToday = !cell.overflow &&
+                            year == todayYear && month == todayMonth && cell.day == todayDay
+                    val dayEvents = if (!cell.overflow) eventsThisMonth.filter { it.day == cell.day } else emptyList()
+
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxSize()
+                            .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                            .clickable(enabled = !cell.overflow) { onDayTap(cell.day) }
+                            .padding(start = 6.dp, end = 4.dp, top = 6.dp, bottom = 4.dp)
+                    ) {
+                        if (isToday) {
+                            Box(
+                                modifier = Modifier
+                                    .size(26.dp)
+                                    .background(Brush.linearGradient(listOf(CBlue, CBlueDark)), CircleShape),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = cell.day.toString(),
+                                    fontSize = 12.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White
+                                )
+                            }
+                        } else {
+                            Text(
+                                text = cell.day.toString(),
+                                fontSize = 12.sp,
+                                fontWeight = if (cell.overflow) FontWeight.Normal else FontWeight.Medium,
+                                color = when {
+                                    cell.overflow -> CMuted2
+                                    selectedDay == cell.day -> CBlue
+                                    else -> CInk
+                                }
+                            )
+                        }
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .fillMaxWidth()
+                                .padding(top = 28.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
+                            dayEvents.take(2).forEach { event ->
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(14.dp)
+                                        .background(eventColor(event.type), RoundedCornerShape(3.dp))
+                                        .padding(horizontal = 4.dp),
+                                    contentAlignment = Alignment.CenterStart
+                                ) {
+                                    Text(
+                                        text = event.title,
+                                        fontSize = 9.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = Color.White,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                            }
+                            if (dayEvents.size > 2) {
+                                Text(
+                                    text = "+${dayEvents.size - 2} more",
+                                    fontSize = 9.sp,
+                                    color = CMuted
+                                )
+                            }
+                        }
+                    }
+                    if (ci < 6) {
+                        Box(
+                            modifier = Modifier
+                                .width(1.dp)
+                                .fillMaxSize()
+                                .background(Brush.verticalGradient(listOf(CHair, CHair)))
                         )
                     }
                 }
@@ -511,136 +452,130 @@ private fun EventsPanel(
 }
 
 @Composable
-private fun PanelEmptyState(message: String) {
+private fun DayEventSheet(
+    events: List<CalendarEvent>,
+    onEventTap: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
     Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .background(
-                Brush.linearGradient(
-                    listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
-                ),
-                RoundedCornerShape(12.dp)
-            )
-            .padding(20.dp),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color(0x731A1A2E), Color(0x731A1A2E))))
+            .clickable(onClick = onDismiss)
     ) {
-        Text(
-            text = message,
-            color = Color.White.copy(alpha = 0.87f),
-            fontSize = 14.sp,
-            textAlign = TextAlign.Center
-        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(listOf(Color.White, CSurface)),
+                    RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+                )
+                .padding(horizontal = 20.dp)
+                .clickable(enabled = false) {}
+        ) {
+            Spacer(Modifier.height(12.dp))
+            Box(
+                modifier = Modifier
+                    .width(36.dp)
+                    .height(4.dp)
+                    .background(Brush.linearGradient(listOf(CHair, CHair)), RoundedCornerShape(2.dp))
+                    .align(Alignment.CenterHorizontally)
+            )
+            Spacer(Modifier.height(20.dp))
+            Text(
+                text = "Events",
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+                color = CInk
+            )
+            Spacer(Modifier.height(12.dp))
+            events.forEach { event ->
+                EventSheetRow(event = event, onTap = { onEventTap(event.id) })
+                Spacer(Modifier.height(8.dp))
+            }
+            Spacer(Modifier.height(24.dp))
+        }
     }
 }
 
 @Composable
-private fun EventPanelCard(
-    event: CalendarEvent,
-    onTap: () -> Unit,
-    onDelete: () -> Unit
-) {
-    val (startColor, endColor) = event.type.gradientColors()
-
+private fun EventSheetRow(event: CalendarEvent, onTap: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(
-                Brush.linearGradient(
-                    listOf(startColor.copy(alpha = 0.12f), endColor.copy(alpha = 0.12f))
-                ),
-                RoundedCornerShape(14.dp)
-            )
-            .clip(RoundedCornerShape(14.dp))
+            .background(Brush.linearGradient(listOf(CSurface, CSurface)), RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onTap)
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
             modifier = Modifier
-                .width(5.dp)
-                .height(46.dp)
-                .background(
-                    Brush.verticalGradient(listOf(startColor, endColor)),
-                    RoundedCornerShape(3.dp)
-                )
+                .width(4.dp)
+                .height(40.dp)
+                .background(eventColor(event.type), RoundedCornerShape(2.dp))
         )
-
-        Spacer(modifier = Modifier.width(12.dp))
-
+        Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
+            Text(text = event.title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = CInk)
             Text(
-                text = event.title,
-                color = Color.White,
-                fontWeight = FontWeight.SemiBold,
-                fontSize = 15.sp
-            )
-            Spacer(modifier = Modifier.height(3.dp))
-            Text(
-                text = stringResource(
-                    R.string.event_time_range,
-                    event.startHour.padded(),
-                    event.startMinute.padded(),
-                    event.endHour.padded(),
-                    event.endMinute.padded()
-                ),
-                color = Color.White.copy(alpha = 0.87f),
-                fontSize = 12.sp
-            )
-            if (event.description.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = event.description,
-                    color = Color.White.copy(alpha = 0.87f),
-                    fontSize = 12.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        Box(
-            modifier = Modifier
-                .background(
-                    Brush.linearGradient(listOf(startColor, endColor)),
-                    RoundedCornerShape(8.dp)
-                )
-                .padding(horizontal = 8.dp, vertical = 4.dp)
-        ) {
-            Text(
-                text = stringResource(event.type.labelRes),
-                color = Color.White,
-                fontSize = 11.sp,
-                fontWeight = FontWeight.SemiBold
+                text = "${formatTime(event.startHour, event.startMinute)} – ${formatTime(event.endHour, event.endMinute)}",
+                fontSize = 12.sp,
+                color = CMuted
             )
         }
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        IconButton(
-            onClick = onDelete,
-            modifier = Modifier.size(48.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Delete,
-                contentDescription = stringResource(R.string.cd_delete_event),
-                tint = Color.White,
-                modifier = Modifier.size(18.dp)
-            )
-        }
+        Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = "View event details",
+            tint = CMuted2,
+            modifier = Modifier.size(16.dp)
+        )
     }
 }
 
-// ── Shared helpers ─────────────────────────────────────────────
+private data class DayCell(val day: Int, val overflow: Boolean)
 
-internal fun Int.padded(): String = toString().padStart(2, '0')
+private fun buildMonthCells(year: Int, month: Int): List<DayCell> {
+    val cal = Calendar.getInstance().apply {
+        set(Calendar.YEAR, year)
+        set(Calendar.MONTH, month - 1)
+        set(Calendar.DAY_OF_MONTH, 1)
+    }
+    val firstDayOfWeek = cal.get(Calendar.DAY_OF_WEEK) - 1
+    val daysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH)
 
-internal fun EventType.gradientColors(): Pair<Color, Color> = when (this) {
-    EventType.WORK -> Color(0xFF6366F1) to Color(0xFF8B5CF6)
-    EventType.PERSONAL -> Color(0xFF06B6D4) to Color(0xFF3B82F6)
-    EventType.HEALTH -> Color(0xFF10B981) to Color(0xFF059669)
-    EventType.SOCIAL -> Color(0xFFF59E0B) to Color(0xFFD97706)
-    EventType.OTHER -> Color(0xFF94A3B8) to Color(0xFF64748B)
+    val prevMonthCal = Calendar.getInstance().apply {
+        set(Calendar.YEAR, year)
+        set(Calendar.MONTH, month - 1)
+        add(Calendar.MONTH, -1)
+    }
+    val daysInPrevMonth = prevMonthCal.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+    val cells = mutableListOf<DayCell>()
+    for (i in firstDayOfWeek downTo 1) {
+        cells.add(DayCell(daysInPrevMonth - i + 1, overflow = true))
+    }
+    for (d in 1..daysInMonth) {
+        cells.add(DayCell(d, overflow = false))
+    }
+    var next = 1
+    while (cells.size < 35) {
+        cells.add(DayCell(next++, overflow = true))
+    }
+    return cells
+}
+
+internal fun eventColor(type: EventType): Color = when (type) {
+    EventType.WORK -> CBlue
+    EventType.PERSONAL -> CCoralColor
+    EventType.HEALTH -> CSuccessColor
+    EventType.SOCIAL -> CWarnColor
+    EventType.OTHER -> CMuted
+}
+
+internal fun formatTime(hour: Int, minute: Int): String {
+    val amPm = if (hour < 12) "AM" else "PM"
+    val h = if (hour == 0) 12 else if (hour > 12) hour - 12 else hour
+    return String.format(Locale.US, "%d:%02d %s", h, minute, amPm)
 }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarUiState.kt
@@ -5,6 +5,8 @@ import com.example.testingapplictionandriod.domain.model.EventType
 
 sealed class CalendarNavScreen {
     object Month : CalendarNavScreen()
+    object DayView : CalendarNavScreen()
+    object WeekView : CalendarNavScreen()
     object CreateEvent : CalendarNavScreen()
     data class EventDetail(val eventId: String) : CalendarNavScreen()
 }
@@ -22,5 +24,6 @@ data class CalendarUiState(
     val newEventStartHour: Int = 9,
     val newEventStartMinute: Int = 0,
     val newEventEndHour: Int = 10,
-    val newEventEndMinute: Int = 0
+    val newEventEndMinute: Int = 0,
+    val showNotifications: Boolean = false
 )

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CalendarViewModel.kt
@@ -81,6 +81,18 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
         _uiState.update { it.copy(currentScreen = CalendarNavScreen.Month) }
     }
 
+    fun onShowDayView() {
+        _uiState.update { it.copy(currentScreen = CalendarNavScreen.DayView) }
+    }
+
+    fun onShowWeekView() {
+        _uiState.update { it.copy(currentScreen = CalendarNavScreen.WeekView) }
+    }
+
+    fun onToggleNotifications() {
+        _uiState.update { it.copy(showNotifications = !it.showNotifications) }
+    }
+
     fun onNewEventTitleChange(title: String) {
         _uiState.update { it.copy(newEventTitle = title) }
     }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/CreateEventScreen.kt
@@ -14,16 +14,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,16 +30,27 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.testingapplictionandriod.R
 import com.example.testingapplictionandriod.domain.model.EventType
-import java.text.SimpleDateFormat
-import java.util.Locale
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CBlueBgSoft = Color(0xFFEEF5FF)
+private val CDanger = Color(0xFFDE3030)
+private val CDangerBg = Color(0xFFFBDADA)
+private val CInk = Color(0xFF1A1A2E)
+private val CInk3 = Color(0xFF3D3D5C)
+private val CMuted = Color(0xFF8B8BA7)
+private val CMuted2 = Color(0xFFC8C8D8)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+private val CSuccessColor = Color(0xFF22C55E)
+private val CWarnColor = Color(0xFFF97316)
+private val CCoralColor = Color(0xFFE85C4A)
+private val CMintInk = Color(0xFF00897B)
 
 @Composable
 fun CreateEventScreen(
@@ -59,344 +68,353 @@ fun CreateEventScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
-                )
-            )
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            // Top bar: close | title | save
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Header
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 10.dp),
+                    .height(52.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = onDismiss) {
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onDismiss),
+                    contentAlignment = Alignment.Center
+                ) {
                     Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = stringResource(R.string.cd_close),
-                        tint = Color.White
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Go back",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
                     )
                 }
                 Text(
-                    text = stringResource(R.string.screen_create_event),
-                    color = Color.White,
+                    text = "New Event",
+                    fontSize = 17.sp,
                     fontWeight = FontWeight.Bold,
-                    fontSize = 20.sp,
+                    color = CInk,
                     modifier = Modifier
                         .weight(1f)
-                        .padding(start = 4.dp)
+                        .padding(horizontal = 12.dp)
                 )
                 Box(
                     modifier = Modifier
-                        .background(
-                            if (uiState.newEventTitle.isNotBlank())
-                                Brush.linearGradient(listOf(Color(0xFF6366F1), Color(0xFF8B5CF6)))
-                            else
-                                Brush.linearGradient(
-                                    listOf(
-                                        Color(0xFF6366F1).copy(alpha = 0.40f),
-                                        Color(0xFF8B5CF6).copy(alpha = 0.40f)
-                                    )
-                                ),
-                            RoundedCornerShape(999.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Brush.linearGradient(listOf(CBlue, CBlueDark)))
+                        .clickable(
+                            enabled = uiState.newEventTitle.isNotBlank(),
+                            onClick = onSave
                         )
-                        .clip(RoundedCornerShape(999.dp))
-                        .clickable(enabled = uiState.newEventTitle.isNotBlank(), onClick = onSave)
-                        .padding(horizontal = 20.dp, vertical = 10.dp)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     Text(
-                        text = stringResource(R.string.btn_save),
+                        text = "Save",
                         color = Color.White,
                         fontWeight = FontWeight.Bold,
-                        fontSize = 14.sp
+                        fontSize = 15.sp
                     )
                 }
-                Spacer(modifier = Modifier.width(8.dp))
             }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
 
-            // Scrollable form body
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 20.dp, vertical = 4.dp),
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                // Large title input
-                BasicTextField(
+                // Title field
+                InputField(
+                    label = "TITLE",
                     value = uiState.newEventTitle,
                     onValueChange = onTitleChange,
-                    textStyle = TextStyle(
-                        color = Color.White,
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.Bold
-                    ),
-                    cursorBrush = SolidColor(Color(0xFF6366F1)),
-                    decorationBox = { innerField ->
-                        Box(modifier = Modifier.fillMaxWidth()) {
-                            if (uiState.newEventTitle.isEmpty()) {
-                                Text(
-                                    text = stringResource(R.string.hint_event_title),
-                                    color = Color.White.copy(alpha = 0.87f),
-                                    fontSize = 28.sp,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                            innerField()
-                        }
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 8.dp)
+                    placeholder = "Event title",
+                    isBig = true
                 )
 
-                // Subtle divider
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(
-                            Brush.linearGradient(
-                                listOf(Color(0xFF6366F1).copy(alpha = 0.10f), Color(0xFF8B5CF6).copy(alpha = 0.10f))
-                            )
+                // Date/time row
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    val selectedDay = uiState.selectedDay
+                    val month = MONTH_NAMES_SHORT[uiState.displayedMonth - 1]
+                    Box(modifier = Modifier.weight(1f)) {
+                        InputFieldStatic(
+                            label = "DATE",
+                            value = if (selectedDay != null) "$month $selectedDay" else "$month —"
                         )
-                )
-
-                // Date row
-                val dateLabel = uiState.selectedDay?.let { day ->
-                    val cal = java.util.Calendar.getInstance().apply {
-                        set(uiState.displayedYear, uiState.displayedMonth - 1, day)
                     }
-                    SimpleDateFormat(stringResource(R.string.date_format_full), Locale.getDefault()).format(cal.time)
-                } ?: run {
-                    val cal = java.util.Calendar.getInstance()
-                    SimpleDateFormat(stringResource(R.string.date_format_full), Locale.getDefault()).format(cal.time)
-                }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            Brush.linearGradient(
-                                listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
-                            ),
-                            RoundedCornerShape(14.dp)
+                    Box(modifier = Modifier.weight(1f)) {
+                        InputFieldStatic(
+                            label = "START",
+                            value = formatTime(uiState.newEventStartHour, uiState.newEventStartMinute)
                         )
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.DateRange,
-                        contentDescription = stringResource(R.string.label_date),
-                        tint = Color.White,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Text(
-                        text = dateLabel,
-                        color = Color.White,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.weight(1f)
-                    )
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        InputFieldStatic(
+                            label = "END",
+                            value = formatTime(uiState.newEventEndHour, uiState.newEventEndMinute)
+                        )
+                    }
                 }
 
-                // Start / End time row
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
+                // Time spinners row
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                     Column(modifier = Modifier.weight(1f)) {
-                        SectionLabel(text = stringResource(R.string.dialog_start_time))
-                        Spacer(modifier = Modifier.height(6.dp))
-                        TimeSpinnerBlock(
+                        Text(
+                            text = "START TIME",
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = CMuted,
+                            letterSpacing = 0.3.sp
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        TimeSpinner(
                             hour = uiState.newEventStartHour,
                             minute = uiState.newEventStartMinute,
                             onHourChange = onStartHourChange,
-                            onMinuteChange = onStartMinuteChange,
-                            hourDescription = stringResource(R.string.cd_start_hour),
-                            minuteDescription = stringResource(R.string.cd_start_minute)
+                            onMinuteChange = onStartMinuteChange
                         )
                     }
                     Column(modifier = Modifier.weight(1f)) {
-                        SectionLabel(text = stringResource(R.string.dialog_end_time))
-                        Spacer(modifier = Modifier.height(6.dp))
-                        TimeSpinnerBlock(
+                        Text(
+                            text = "END TIME",
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = CMuted,
+                            letterSpacing = 0.3.sp
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        TimeSpinner(
                             hour = uiState.newEventEndHour,
                             minute = uiState.newEventEndMinute,
                             onHourChange = onEndHourChange,
-                            onMinuteChange = onEndMinuteChange,
-                            hourDescription = stringResource(R.string.cd_end_hour),
-                            minuteDescription = stringResource(R.string.cd_end_minute)
+                            onMinuteChange = onEndMinuteChange
                         )
                     }
                 }
 
-                // Event type chips
-                SectionLabel(text = stringResource(R.string.dialog_event_type_label))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    EventType.entries.forEach { type ->
-                        val isSelected = uiState.newEventType == type
-                        val (sc, ec) = type.gradientColors()
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .background(
-                                    if (isSelected) Brush.linearGradient(listOf(sc, ec))
-                                    else Brush.linearGradient(
-                                        listOf(sc.copy(alpha = 0.15f), ec.copy(alpha = 0.15f))
-                                    ),
-                                    RoundedCornerShape(10.dp)
+                // Event type
+                Column {
+                    Text(
+                        text = "TYPE",
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CMuted,
+                        letterSpacing = 0.3.sp
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        EventType.entries.forEach { type ->
+                            val isSelected = uiState.newEventType == type
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(36.dp)
+                                    .background(
+                                        if (isSelected) Brush.linearGradient(
+                                            listOf(
+                                                eventColor(type),
+                                                eventColor(type)
+                                            )
+                                        )
+                                        else Brush.linearGradient(listOf(Color.White, Color.White)),
+                                        RoundedCornerShape(10.dp)
+                                    )
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .clickable { onTypeChange(type) },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = type.name.take(4),
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (isSelected) Color.White else CMuted
                                 )
-                                .clip(RoundedCornerShape(10.dp))
-                                .clickable { onTypeChange(type) }
-                                .padding(vertical = 8.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = stringResource(type.labelRes),
-                                color = Color.White,
-                                fontSize = 11.sp,
-                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                                textAlign = TextAlign.Center
-                            )
+                            }
                         }
                     }
                 }
 
-                // Notes / description
-                SectionLabel(text = stringResource(R.string.label_notes))
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            Brush.linearGradient(
-                                listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
-                            ),
-                            RoundedCornerShape(14.dp)
-                        )
-                        .padding(16.dp)
-                ) {
-                    BasicTextField(
-                        value = uiState.newEventDescription,
-                        onValueChange = onDescriptionChange,
-                        textStyle = TextStyle(
-                            color = Color.White,
-                            fontSize = 15.sp
-                        ),
-                        cursorBrush = SolidColor(Color(0xFF6366F1)),
-                        minLines = 3,
-                        decorationBox = { innerField ->
-                            if (uiState.newEventDescription.isEmpty()) {
-                                Text(
-                                    text = stringResource(R.string.hint_add_notes),
-                                    color = Color.White.copy(alpha = 0.87f),
-                                    fontSize = 15.sp
-                                )
-                            }
-                            innerField()
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
+                // Description field
+                InputField(
+                    label = "NOTES",
+                    value = uiState.newEventDescription,
+                    onValueChange = onDescriptionChange,
+                    placeholder = "Add notes…",
+                    minLines = 3
+                )
             }
         }
     }
 }
 
 @Composable
-private fun SectionLabel(text: String) {
-    Text(
-        text = text.uppercase(),
-        color = Color.White.copy(alpha = 0.87f),
-        fontSize = 11.sp,
-        fontWeight = FontWeight.Bold,
-        letterSpacing = 0.8.sp
-    )
+private fun InputField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String = "",
+    isBig: Boolean = false,
+    minLines: Int = 1
+) {
+    Column {
+        Text(
+            text = label,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.3.sp
+        )
+        Spacer(Modifier.height(6.dp))
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = TextStyle(
+                fontSize = if (isBig) 16.sp else 14.sp,
+                fontWeight = if (isBig) FontWeight.SemiBold else FontWeight.Normal,
+                color = CInk
+            ),
+            cursorBrush = SolidColor(CBlue),
+            minLines = minLines,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(listOf(Color.White, Color.White)),
+                    RoundedCornerShape(12.dp)
+                )
+                .padding(14.dp),
+            decorationBox = { inner ->
+                if (value.isEmpty()) {
+                    Text(text = placeholder, color = CMuted2, fontSize = if (isBig) 16.sp else 14.sp)
+                }
+                inner()
+            }
+        )
+    }
 }
 
 @Composable
-private fun TimeSpinnerBlock(
+private fun InputFieldStatic(label: String, value: String) {
+    Column {
+        Text(
+            text = label,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.3.sp
+        )
+        Spacer(Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .background(
+                    Brush.verticalGradient(listOf(Color.White, Color.White)),
+                    RoundedCornerShape(10.dp)
+                )
+                .padding(horizontal = 10.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            Text(text = value, fontSize = 13.sp, fontWeight = FontWeight.Medium, color = CInk)
+        }
+    }
+}
+
+@Composable
+private fun TimeSpinner(
     hour: Int,
     minute: Int,
     onHourChange: (Int) -> Unit,
-    onMinuteChange: (Int) -> Unit,
-    hourDescription: String,
-    minuteDescription: String
+    onMinuteChange: (Int) -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(
-                Brush.linearGradient(
-                    listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
-                ),
+                Brush.verticalGradient(listOf(Color.White, Color.White)),
                 RoundedCornerShape(12.dp)
             )
-            .padding(horizontal = 8.dp, vertical = 4.dp),
+            .padding(horizontal = 12.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
-        SpinnerWheel(
+        SpinnerPicker(
             value = hour,
-            onIncrement = { onHourChange((hour + 1) % 24) },
-            onDecrement = { onHourChange((hour - 1 + 24) % 24) },
-            description = hourDescription
+            range = 0..23,
+            onInc = { onHourChange((hour + 1) % 24) },
+            onDec = { onHourChange((hour - 1 + 24) % 24) },
+            format = { "%02d".format(it) }
         )
         Text(
-            text = stringResource(R.string.time_separator),
-            color = Color.White,
+            text = ":",
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
+            color = CInk,
             modifier = Modifier.padding(horizontal = 4.dp)
         )
-        SpinnerWheel(
+        SpinnerPicker(
             value = minute,
-            onIncrement = { onMinuteChange((minute + 15) % 60) },
-            onDecrement = { onMinuteChange((minute - 15 + 60) % 60) },
-            description = minuteDescription
+            range = 0..59,
+            onInc = { onMinuteChange((minute + 15) % 60) },
+            onDec = { onMinuteChange((minute - 15 + 60) % 60) },
+            format = { "%02d".format(it) }
         )
     }
 }
 
 @Composable
-private fun SpinnerWheel(
+private fun SpinnerPicker(
     value: Int,
-    onIncrement: () -> Unit,
-    onDecrement: () -> Unit,
-    description: String
+    range: IntRange,
+    onInc: () -> Unit,
+    onDec: () -> Unit,
+    format: (Int) -> String
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        IconButton(onClick = onIncrement, modifier = Modifier.size(48.dp)) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowUp,
-                contentDescription = stringResource(R.string.cd_increase_value, description),
-                tint = Color.White.copy(alpha = 0.87f),
-                modifier = Modifier.size(16.dp)
-            )
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(CSurface, RoundedCornerShape(8.dp))
+                .clickable(onClick = onInc),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "▲", fontSize = 10.sp, color = CBlue)
         }
+        Spacer(Modifier.height(4.dp))
         Text(
-            text = value.padded(),
-            color = Color.White,
-            fontSize = 18.sp,
+            text = format(value),
+            fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center
+            color = CInk
         )
-        IconButton(onClick = onDecrement, modifier = Modifier.size(48.dp)) {
-            Icon(
-                imageVector = Icons.Filled.KeyboardArrowDown,
-                contentDescription = stringResource(R.string.cd_decrease_value, description),
-                tint = Color.White.copy(alpha = 0.87f),
-                modifier = Modifier.size(16.dp)
-            )
+        Spacer(Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(CSurface, RoundedCornerShape(8.dp))
+                .clickable(onClick = onDec),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "▼", fontSize = 10.sp, color = CBlue)
         }
     }
 }
+
+private val MONTH_NAMES_SHORT = listOf(
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/DayViewScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/DayViewScreen.kt
@@ -1,0 +1,293 @@
+package com.example.testingapplictionandriod.ui.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.domain.model.CalendarEvent
+import com.example.testingapplictionandriod.ui.components.CalenderlyFab
+import com.example.testingapplictionandriod.ui.components.UpgradeBanner
+import java.util.Calendar
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CDangerRed = Color(0xFFDE3030)
+private val CInk = Color(0xFF1A1A2E)
+private val CMuted = Color(0xFF8B8BA7)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+
+private val MONTH_NAMES_DAY = listOf(
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+)
+private val WEEK_DAYS = listOf("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+private val HOUR_LABELS = listOf("8 AM", "9 AM", "10 AM", "11 AM", "12 PM", "1 PM", "2 PM", "3 PM", "4 PM", "5 PM", "6 PM")
+
+@Composable
+fun DayViewScreen(
+    uiState: CalendarUiState,
+    onBack: () -> Unit,
+    onShowCreateEvent: () -> Unit
+) {
+    val today = remember { Calendar.getInstance() }
+    val displayDay = uiState.selectedDay ?: today.get(Calendar.DAY_OF_MONTH)
+    val todayDay = today.get(Calendar.DAY_OF_MONTH)
+    val todayMonth = today.get(Calendar.MONTH) + 1
+    val todayYear = today.get(Calendar.YEAR)
+
+    val isToday = displayDay == todayDay &&
+            uiState.displayedMonth == todayMonth &&
+            uiState.displayedYear == todayYear
+
+    val dayEvents = uiState.events.filter { e ->
+        e.year == uiState.displayedYear &&
+                e.month == uiState.displayedMonth &&
+                e.day == displayDay
+    }
+
+    // Build week strip around displayed day
+    val cal = remember(uiState.displayedYear, uiState.displayedMonth, displayDay) {
+        Calendar.getInstance().apply {
+            set(uiState.displayedYear, uiState.displayedMonth - 1, displayDay)
+        }
+    }
+    val dayOfWeek = cal.get(Calendar.DAY_OF_WEEK) - 1 // 0=Sun
+    val weekDays = remember(displayDay) {
+        (-dayOfWeek..6 - dayOfWeek).map { offset ->
+            val c = Calendar.getInstance().apply {
+                set(uiState.displayedYear, uiState.displayedMonth - 1, displayDay)
+                add(Calendar.DAY_OF_MONTH, offset)
+            }
+            Triple(
+                WEEK_DAYS[c.get(Calendar.DAY_OF_WEEK) - 1],
+                c.get(Calendar.DAY_OF_MONTH),
+                offset == 0
+            )
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onBack),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Back to month view",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = if (isToday) "Today" else MONTH_NAMES_DAY[uiState.displayedMonth - 1],
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CInk
+                    )
+                    Text(
+                        text = "${MONTH_NAMES_DAY[uiState.displayedMonth - 1]} $displayDay, ${uiState.displayedYear}",
+                        fontSize = 11.sp,
+                        color = CMuted,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = "Search events",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            // Week date strip
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(72.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
+            ) {
+                weekDays.forEach { (dayLabel, dayNum, isCurrentDay) ->
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(
+                                if (isCurrentDay) Brush.linearGradient(listOf(CBlue, CBlueDark))
+                                else Brush.verticalGradient(listOf(Color.Transparent, Color.Transparent))
+                            )
+                            .padding(vertical = 6.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = dayLabel.uppercase().take(3),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = if (isCurrentDay) Color.White.copy(alpha = 0.87f) else CMuted
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = dayNum.toString(),
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = if (isCurrentDay) Color.White else CInk
+                        )
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            // Timeline
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    Box(modifier = Modifier.fillMaxWidth().height(16.dp))
+                    HOUR_LABELS.forEachIndexed { i, label ->
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp)
+                        ) {
+                            Text(
+                                text = label,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = CMuted,
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .padding(start = 12.dp, top = -5.dp)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(1.dp)
+                                    .padding(start = 56.dp)
+                                    .align(Alignment.TopCenter)
+                                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+                            )
+                            // Events for this hour
+                            dayEvents.filter { e ->
+                                e.startHour == i + 8
+                            }.forEach { event ->
+                                val durationH = ((event.endHour * 60 + event.endMinute) -
+                                        (event.startHour * 60 + event.startMinute)).coerceAtLeast(30)
+                                val heightDp = (durationH.toFloat() / 60f * 50f).dp
+                                Box(
+                                    modifier = Modifier
+                                        .padding(start = 60.dp, end = 12.dp, top = 2.dp)
+                                        .fillMaxWidth()
+                                        .height(heightDp.coerceAtLeast(30.dp))
+                                        .background(
+                                            Brush.linearGradient(
+                                                listOf(eventColor(event.type), eventColor(event.type))
+                                            ),
+                                            RoundedCornerShape(10.dp)
+                                        )
+                                        .padding(8.dp)
+                                ) {
+                                    Column {
+                                        Text(
+                                            text = event.title,
+                                            fontSize = 13.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.White
+                                        )
+                                        Text(
+                                            text = "${formatTime(event.startHour, event.startMinute)}–${formatTime(event.endHour, event.endMinute)}",
+                                            fontSize = 10.sp,
+                                            color = Color.White.copy(alpha = 0.87f)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Box(modifier = Modifier.fillMaxWidth().height(120.dp))
+                }
+            }
+
+            UpgradeBanner()
+        }
+
+        CalenderlyFab(
+            onClick = onShowCreateEvent,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 20.dp, bottom = 144.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/EventDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.example.testingapplictionandriod.ui.calendar
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,29 +11,47 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.testingapplictionandriod.R
 import com.example.testingapplictionandriod.domain.model.CalendarEvent
-import java.text.SimpleDateFormat
-import java.util.Locale
+import com.example.testingapplictionandriod.domain.model.EventType
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CBlueBgSoft = Color(0xFFEEF5FF)
+private val CDanger = Color(0xFFDE3030)
+private val CDangerBg = Color(0xFFFBDADA)
+private val CInk = Color(0xFF1A1A2E)
+private val CInk3 = Color(0xFF3D3D5C)
+private val CMuted = Color(0xFF8B8BA7)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+
+private val MONTH_NAMES_FULL = listOf(
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+)
 
 @Composable
 fun EventDetailScreen(
@@ -40,276 +59,224 @@ fun EventDetailScreen(
     onBack: () -> Unit,
     onDelete: () -> Unit
 ) {
-    val (startColor, endColor) = event.type.gradientColors()
+    val typeColor = eventColor(event.type)
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color(0xFF0F0C29), Color(0xFF302B63), Color(0xFF24243E))
-                )
-            )
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-
-            // ── Hero header ──────────────────────────────────────
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onBack),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Go back",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Text(
+                    text = "Event Details",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 8.dp)
+                )
+            }
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(
-                        Brush.linearGradient(listOf(startColor, endColor))
-                    )
-            ) {
-                Column {
-                    // Action row
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 8.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        IconButton(onClick = onBack) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = stringResource(R.string.cd_back),
-                                tint = Color.White
-                            )
-                        }
-                        Spacer(modifier = Modifier.weight(1f))
-                        IconButton(onClick = onDelete) {
-                            Icon(
-                                imageVector = Icons.Filled.Delete,
-                                contentDescription = stringResource(R.string.cd_delete_event),
-                                tint = Color.White
-                            )
-                        }
-                    }
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
 
-                    // Event metadata
-                    Column(
-                        modifier = Modifier.padding(
-                            start = 20.dp, end = 20.dp, top = 4.dp, bottom = 28.dp
-                        )
-                    ) {
-                        // Category pill
-                        Box(
-                            modifier = Modifier
-                                .background(
-                                    Brush.linearGradient(
-                                        listOf(Color(0xFF6366F1).copy(alpha = 0.20f), Color(0xFF8B5CF6).copy(alpha = 0.20f))
-                                    ),
-                                    RoundedCornerShape(999.dp)
-                                )
-                                .padding(horizontal = 12.dp, vertical = 5.dp)
-                        ) {
-                            Text(
-                                text = stringResource(event.type.labelRes),
-                                color = Color.White,
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.height(12.dp))
-
-                        Text(
-                            text = event.title,
-                            color = Color.White,
-                            fontSize = 30.sp,
-                            fontWeight = FontWeight.Bold,
-                            lineHeight = 34.sp
-                        )
-
-                        Spacer(modifier = Modifier.height(10.dp))
-
-                        val cal = java.util.Calendar.getInstance().apply {
-                            set(event.year, event.month - 1, event.day)
-                        }
-                        val dateStr = SimpleDateFormat(
-                            stringResource(R.string.date_format_day_month), Locale.getDefault()
-                        ).format(cal.time)
-                        Text(
-                            text = stringResource(
-                                R.string.event_detail_datetime,
-                                dateStr,
-                                event.startHour.padded(),
-                                event.startMinute.padded(),
-                                event.endHour.padded(),
-                                event.endMinute.padded()
-                            ),
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontSize = 14.sp
-                        )
-                    }
-                }
-            }
-
-            // ── Body content ─────────────────────────────────────
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
             ) {
-
-                // Stats card
-                val durationMins = (event.endHour * 60 + event.endMinute) -
-                        (event.startHour * 60 + event.startMinute)
-                val durationText = when {
-                    durationMins <= 0 -> stringResource(R.string.duration_na)
-                    durationMins < 60 -> stringResource(R.string.duration_minutes, durationMins)
-                    durationMins % 60 == 0 -> stringResource(R.string.duration_hours, durationMins / 60)
-                    else -> stringResource(
-                        R.string.duration_hours_minutes, durationMins / 60, durationMins % 60
-                    )
-                }
-
-                Row(
+                // Event title card
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .background(
-                            Brush.linearGradient(
-                                listOf(Color(0xFF6366F1).copy(alpha = 0.08f), Color(0xFF8B5CF6).copy(alpha = 0.08f))
-                            ),
+                            Brush.verticalGradient(listOf(Color.White, CSurface)),
                             RoundedCornerShape(16.dp)
                         )
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
+                        .padding(20.dp)
                 ) {
-                    StatItem(
-                        label = stringResource(R.string.label_duration),
-                        value = durationText
+                    Column {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(
+                                modifier = Modifier
+                                    .width(4.dp)
+                                    .height(24.dp)
+                                    .background(typeColor, RoundedCornerShape(2.dp))
+                            )
+                            Spacer(Modifier.width(10.dp))
+                            Text(
+                                text = event.title,
+                                fontSize = 21.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = CInk,
+                                letterSpacing = (-0.3).sp
+                            )
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Box(
+                            modifier = Modifier
+                                .background(CBlueBgSoft, RoundedCornerShape(6.dp))
+                                .padding(horizontal = 8.dp, vertical = 3.dp)
+                        ) {
+                            Text(
+                                text = event.type.name.lowercase()
+                                    .replaceFirstChar { it.uppercase() },
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = CBlue
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                // Date and time info
+                DetailRow(
+                    icon = Icons.Filled.CalendarMonth,
+                    title = "${MONTH_NAMES_FULL[event.month - 1]} ${event.day}, ${event.year}",
+                    subtitle = "${formatTime(event.startHour, event.startMinute)} – ${formatTime(event.endHour, event.endMinute)}"
+                )
+                Spacer(Modifier.height(8.dp))
+                DetailRow(
+                    icon = Icons.Filled.Schedule,
+                    title = "Duration",
+                    subtitle = formatDuration(event.startHour, event.startMinute, event.endHour, event.endMinute)
+                )
+
+                if (event.description.isNotBlank()) {
+                    Spacer(Modifier.height(20.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(Brush.verticalGradient(listOf(CHair, CHair)))
                     )
-                    StatDivider()
-                    StatItem(
-                        label = stringResource(R.string.label_event_type),
-                        value = stringResource(event.type.labelRes)
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = "NOTES",
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CMuted,
+                        letterSpacing = 0.5.sp
                     )
-                    StatDivider()
-                    StatItem(
-                        label = stringResource(R.string.label_date),
-                        value = stringResource(R.string.event_date_short, event.day, event.month)
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = event.description,
+                        fontSize = 14.sp,
+                        color = CInk3,
+                        lineHeight = 20.sp
                     )
                 }
 
-                // Time detail card
-                DetailSection(title = stringResource(R.string.label_time)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                Spacer(Modifier.height(32.dp))
+
+                // Action buttons
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp)
+                            .background(
+                                Brush.linearGradient(listOf(CBlueBgSoft, CBlueBgSoft)),
+                                RoundedCornerShape(12.dp)
+                            )
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { },
+                        contentAlignment = Alignment.Center
                     ) {
-                        Column {
-                            Text(
-                                text = stringResource(R.string.dialog_start_time).uppercase(),
-                                color = Color.White.copy(alpha = 0.87f),
-                                fontSize = 11.sp,
-                                fontWeight = FontWeight.Bold
+                        Text(text = "Edit", color = CBlue, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+                    }
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp)
+                            .background(
+                                Brush.linearGradient(listOf(CDangerBg, CDangerBg)),
+                                RoundedCornerShape(12.dp)
                             )
-                            Text(
-                                text = stringResource(R.string.time_hhmm, event.startHour.padded(), event.startMinute.padded()),
-                                color = Color.White,
-                                fontSize = 26.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                        Text(
-                            text = stringResource(R.string.cd_time_arrow),
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontSize = 20.sp
-                        )
-                        Column {
-                            Text(
-                                text = stringResource(R.string.dialog_end_time).uppercase(),
-                                color = Color.White.copy(alpha = 0.87f),
-                                fontSize = 11.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                            Text(
-                                text = stringResource(R.string.time_hhmm, event.endHour.padded(), event.endMinute.padded()),
-                                color = Color.White,
-                                fontSize = 26.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable(onClick = onDelete),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(text = "Delete", color = CDanger, fontWeight = FontWeight.Bold, fontSize = 14.sp)
                     }
                 }
-
-                // Description / notes card (only if non-empty)
-                if (event.description.isNotEmpty()) {
-                    DetailSection(title = stringResource(R.string.label_notes)) {
-                        Text(
-                            text = event.description,
-                            color = Color.White.copy(alpha = 0.87f),
-                            fontSize = 15.sp,
-                            lineHeight = 22.sp
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }
 }
 
 @Composable
-private fun StatItem(label: String, value: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            text = label,
-            color = Color.White.copy(alpha = 0.87f),
-            fontSize = 11.sp,
-            fontWeight = FontWeight.SemiBold
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = value,
-            color = Color.White,
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Bold
-        )
-    }
-}
-
-@Composable
-private fun StatDivider() {
-    Box(
-        modifier = Modifier
-            .width(1.dp)
-            .height(36.dp)
-            .background(
-                Brush.linearGradient(
-                    listOf(Color(0xFF6366F1).copy(alpha = 0.12f), Color(0xFF8B5CF6).copy(alpha = 0.12f))
-                )
-            )
-    )
-}
-
-@Composable
-private fun DetailSection(title: String, content: @Composable () -> Unit) {
-    Column(
+private fun DetailRow(icon: ImageVector, title: String, subtitle: String) {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(
-                Brush.linearGradient(
-                    listOf(Color(0xFF6366F1).copy(alpha = 0.06f), Color(0xFF8B5CF6).copy(alpha = 0.06f))
-                ),
-                RoundedCornerShape(14.dp)
+                Brush.verticalGradient(listOf(Color.White, CSurface)),
+                RoundedCornerShape(12.dp)
             )
             .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = title.uppercase(),
-            color = Color.White.copy(alpha = 0.87f),
-            fontSize = 11.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 1.sp
-        )
-        content()
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .background(CSurface, RoundedCornerShape(10.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = CMuted,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(text = title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = CInk)
+            Text(text = subtitle, fontSize = 12.sp, color = CMuted)
+        }
+    }
+}
+
+private fun formatDuration(startH: Int, startM: Int, endH: Int, endM: Int): String {
+    val startMins = startH * 60 + startM
+    val endMins = endH * 60 + endM
+    val diff = endMins - startMins
+    if (diff <= 0) return "—"
+    val h = diff / 60
+    val m = diff % 60
+    return when {
+        h == 0 -> "$m min"
+        m == 0 -> "$h hr"
+        else -> "$h hr $m min"
     }
 }

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/WeekViewScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/calendar/WeekViewScreen.kt
@@ -1,0 +1,307 @@
+package com.example.testingapplictionandriod.ui.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.ui.components.CalenderlyFab
+import com.example.testingapplictionandriod.ui.components.UpgradeBanner
+import java.util.Calendar
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CDangerRed = Color(0xFFDE3030)
+private val CInk = Color(0xFF1A1A2E)
+private val CMuted = Color(0xFF8B8BA7)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+
+private val WEEK_DAY_LETTERS = listOf("M", "T", "W", "T", "F", "S", "S")
+
+@Composable
+fun WeekViewScreen(
+    uiState: CalendarUiState,
+    onBack: () -> Unit
+) {
+    val today = remember { Calendar.getInstance() }
+    val todayYear = today.get(Calendar.YEAR)
+    val todayMonth = today.get(Calendar.MONTH) + 1
+    val todayDay = today.get(Calendar.DAY_OF_MONTH)
+
+    // Find the start of the week containing the selected day or today
+    val anchorDay = uiState.selectedDay ?: todayDay
+    val anchorCal = remember(uiState.displayedYear, uiState.displayedMonth, anchorDay) {
+        Calendar.getInstance().apply {
+            set(uiState.displayedYear, uiState.displayedMonth - 1, anchorDay)
+        }
+    }
+    val dayOfWeek = anchorCal.get(Calendar.DAY_OF_WEEK) // 1=Sun
+    val offsetToMonday = if (dayOfWeek == Calendar.SUNDAY) -6 else 2 - dayOfWeek
+
+    val weekDays = remember(uiState.displayedYear, uiState.displayedMonth, anchorDay) {
+        (0..6).map { i ->
+            Calendar.getInstance().apply {
+                set(uiState.displayedYear, uiState.displayedMonth - 1, anchorDay)
+                add(Calendar.DAY_OF_MONTH, offsetToMonday + i)
+            }
+        }
+    }
+
+    val firstDay = weekDays.first()
+    val lastDay = weekDays.last()
+    val headerTitle = "Apr ${firstDay.get(Calendar.DAY_OF_MONTH)} – ${lastDay.get(Calendar.DAY_OF_MONTH)}"
+    val weekNum = firstDay.get(Calendar.WEEK_OF_YEAR)
+
+    val hourH = 34.dp
+    val timeColW = 40.dp
+    val hourLabels = (8..17).map { h -> if (h < 12) "${h}AM" else "${h - 12}PM" }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onBack),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Back to month view",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = headerTitle,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CInk
+                    )
+                    Text(
+                        text = "Week $weekNum · ${uiState.displayedYear}",
+                        fontSize = 11.sp,
+                        color = CMuted
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .background(CSurface, RoundedCornerShape(8.dp))
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable(onClick = onBack)
+                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.GridView,
+                        contentDescription = "Switch view",
+                        tint = CInk,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(text = "Week", fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = CInk)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            // Day header row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+            ) {
+                Box(modifier = Modifier.width(timeColW))
+                weekDays.forEachIndexed { i, dayCal ->
+                    val dayNum = dayCal.get(Calendar.DAY_OF_MONTH)
+                    val isTodayDay = dayNum == todayDay &&
+                            dayCal.get(Calendar.MONTH) + 1 == todayMonth &&
+                            dayCal.get(Calendar.YEAR) == todayYear
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxSize()
+                            .background(
+                                if (i > 0) Brush.verticalGradient(listOf(CHair, CHair))
+                                else Brush.verticalGradient(listOf(Color.White, Color.White))
+                            )
+                            .padding(start = if (i > 0) 1.dp else 0.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = WEEK_DAY_LETTERS.getOrElse(i) { "?" },
+                                fontSize = 9.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = CMuted
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            if (isTodayDay) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(22.dp)
+                                        .background(Brush.linearGradient(listOf(CBlue, CBlueDark)), CircleShape),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = dayNum.toString(),
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = Color.White
+                                    )
+                                }
+                            } else {
+                                Text(
+                                    text = dayNum.toString(),
+                                    fontSize = 13.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = if (i >= 5) CMuted else CInk
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            // Grid
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    hourLabels.forEachIndexed { i, label ->
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(hourH)
+                        ) {
+                            Text(
+                                text = label,
+                                fontSize = 9.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                color = CMuted,
+                                modifier = Modifier
+                                    .width(timeColW)
+                                    .align(Alignment.TopStart)
+                                    .padding(end = 4.dp),
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(1.dp)
+                                    .padding(start = timeColW)
+                                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+                            )
+                            // Events for each day in this hour
+                            weekDays.forEachIndexed { colIdx, dayCal ->
+                                val dayNum = dayCal.get(Calendar.DAY_OF_MONTH)
+                                val dayMonth = dayCal.get(Calendar.MONTH) + 1
+                                val dayYear = dayCal.get(Calendar.YEAR)
+                                val colEvents = uiState.events.filter { e ->
+                                    e.year == dayYear && e.month == dayMonth && e.day == dayNum && e.startHour == i + 8
+                                }
+                                colEvents.take(1).forEach { event ->
+                                    val colFraction = 1f / 7f
+                                    val startX = timeColW + (colFraction * colIdx * 320).dp
+                                    val eventH = ((event.endHour * 60 + event.endMinute -
+                                            event.startHour * 60 - event.startMinute).toFloat() / 60f * hourH.value).dp
+                                    Box(
+                                        modifier = Modifier
+                                            .padding(start = timeColW + (colFraction * colIdx * 300).dp, end = 2.dp)
+                                            .width((300.dp * colFraction).coerceAtLeast(30.dp))
+                                            .height(eventH.coerceAtLeast(20.dp))
+                                            .background(
+                                                Brush.linearGradient(
+                                                    listOf(eventColor(event.type), eventColor(event.type))
+                                                ),
+                                                RoundedCornerShape(5.dp)
+                                            )
+                                            .padding(3.dp)
+                                    ) {
+                                        Text(
+                                            text = event.title.take(8),
+                                            fontSize = 9.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.White,
+                                            maxLines = 1
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Box(Modifier.height(100.dp))
+                }
+            }
+
+            UpgradeBanner()
+        }
+
+        CalenderlyFab(
+            onClick = {},
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 20.dp, bottom = 144.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/components/Components.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/components/Components.kt
@@ -1,0 +1,162 @@
+package com.example.testingapplictionandriod.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val PrimaryBlue = Color(0xFF2564CF)
+private val PrimaryBlueDark = Color(0xFF1A3A80)
+private val PrimaryBlueBgSoft = Color(0xFFEEF5FF)
+private val HairColor = Color(0xFFE4E4ED)
+private val InkColor = Color(0xFF1A1A2E)
+private val MutedColor = Color(0xFF8B8BA7)
+private val SurfaceColor = Color(0xFFF7F7FB)
+
+@Composable
+fun CalenderlyButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(52.dp)
+            .background(
+                brush = if (enabled) {
+                    Brush.linearGradient(listOf(PrimaryBlue, PrimaryBlueDark))
+                } else {
+                    Brush.linearGradient(listOf(Color(0xFFBACAED), Color(0xFFBACAED)))
+                },
+                shape = RoundedCornerShape(14.dp)
+            )
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 15.sp
+        )
+    }
+}
+
+@Composable
+fun CalenderlyOutlineButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    color: Color = PrimaryBlue
+) {
+    Box(
+        modifier = modifier
+            .height(44.dp)
+            .background(
+                Brush.linearGradient(listOf(Color.White, Color.White)),
+                RoundedCornerShape(12.dp)
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            color = color,
+            fontWeight = FontWeight.Bold,
+            fontSize = 14.sp
+        )
+    }
+}
+
+@Composable
+fun CalenderlyFab(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(56.dp)
+            .shadow(8.dp, RoundedCornerShape(18.dp))
+            .background(
+                Brush.linearGradient(listOf(PrimaryBlue, PrimaryBlueDark)),
+                RoundedCornerShape(18.dp)
+            )
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Add,
+            contentDescription = "Create new item",
+            tint = Color.White,
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}
+
+@Composable
+fun UpgradeBanner(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(
+                Brush.linearGradient(listOf(Color(0xFFEEF4FF), Color(0xFFFFF7ED)))
+            )
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .background(
+                    Brush.linearGradient(listOf(PrimaryBlue, PrimaryBlueDark)),
+                    RoundedCornerShape(10.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "★", color = Color.White, fontSize = 14.sp)
+        }
+        Box(modifier = Modifier.weight(1f)) {
+            androidx.compose.foundation.layout.Column {
+                Text(
+                    text = "Upgrade to PRO",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = InkColor
+                )
+                Text(
+                    text = "Remove ads · Unlock all features",
+                    fontSize = 11.sp,
+                    color = MutedColor
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/main/MainScreen.kt
@@ -1,0 +1,195 @@
+package com.example.testingapplictionandriod.ui.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.NoteAlt
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.testingapplictionandriod.domain.model.TaskPriority
+import com.example.testingapplictionandriod.ui.app.AppViewModel
+import com.example.testingapplictionandriod.ui.app.MainTab
+import com.example.testingapplictionandriod.ui.calendar.CalendarScreen
+import com.example.testingapplictionandriod.ui.calendar.CalendarViewModel
+import com.example.testingapplictionandriod.ui.mine.MineScreen
+import com.example.testingapplictionandriod.ui.notes.NotesScreen
+import com.example.testingapplictionandriod.ui.notes.NotesViewModel
+import com.example.testingapplictionandriod.ui.tasks.TasksScreen
+import com.example.testingapplictionandriod.ui.tasks.TasksViewModel
+
+private val CBlue = Color(0xFF2564CF)
+private val CMuted = Color(0xFF8B8BA7)
+private val CHair = Color(0xFFE4E4ED)
+private val CInk = Color(0xFF1A1A2E)
+
+@Composable
+fun MainScreen(appViewModel: AppViewModel) {
+    val appState by appViewModel.uiState.collectAsStateWithLifecycle()
+    val calendarViewModel: CalendarViewModel = viewModel()
+    val tasksViewModel: TasksViewModel = viewModel()
+    val notesViewModel: NotesViewModel = viewModel()
+
+    val calendarUiState by calendarViewModel.uiState.collectAsStateWithLifecycle()
+    val tasksUiState by tasksViewModel.uiState.collectAsStateWithLifecycle()
+    val notesUiState by notesViewModel.uiState.collectAsStateWithLifecycle()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Content area (fills above tab bar)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 83.dp)
+        ) {
+            when (appState.selectedTab) {
+                MainTab.CALENDAR -> CalendarScreen(
+                    uiState = calendarUiState,
+                    onPreviousMonth = calendarViewModel::onPreviousMonth,
+                    onNextMonth = calendarViewModel::onNextMonth,
+                    onGoToToday = calendarViewModel::onGoToToday,
+                    onDaySelected = calendarViewModel::onDaySelected,
+                    onShowCreateEvent = calendarViewModel::onShowCreateEvent,
+                    onDismissCreateEvent = calendarViewModel::onDismissCreateEvent,
+                    onNewEventTitleChange = calendarViewModel::onNewEventTitleChange,
+                    onNewEventDescriptionChange = calendarViewModel::onNewEventDescriptionChange,
+                    onNewEventTypeChange = calendarViewModel::onNewEventTypeChange,
+                    onNewEventStartHourChange = calendarViewModel::onNewEventStartHourChange,
+                    onNewEventStartMinuteChange = calendarViewModel::onNewEventStartMinuteChange,
+                    onNewEventEndHourChange = calendarViewModel::onNewEventEndHourChange,
+                    onNewEventEndMinuteChange = calendarViewModel::onNewEventEndMinuteChange,
+                    onAddEvent = calendarViewModel::onAddEvent,
+                    onDeleteEvent = calendarViewModel::onDeleteEvent,
+                    onShowEventDetail = calendarViewModel::onShowEventDetail,
+                    onBackToCalendar = calendarViewModel::onBackToCalendar,
+                    onShowDayView = calendarViewModel::onShowDayView,
+                    onShowWeekView = calendarViewModel::onShowWeekView,
+                    onToggleNotifications = calendarViewModel::onToggleNotifications
+                )
+                MainTab.TASKS -> TasksScreen(
+                    uiState = tasksUiState,
+                    onShowCreate = tasksViewModel::onShowCreate,
+                    onDismissCreate = tasksViewModel::onDismissCreate,
+                    onTitleChange = tasksViewModel::onTitleChange,
+                    onNotesChange = tasksViewModel::onNotesChange,
+                    onPriorityChange = tasksViewModel::onPriorityChange,
+                    onCreateTask = tasksViewModel::onCreateTask,
+                    onToggleComplete = tasksViewModel::onToggleComplete,
+                    onShowDetail = tasksViewModel::onShowDetail,
+                    onDeleteTask = tasksViewModel::onDeleteTask,
+                    onBackToList = tasksViewModel::onBackToList
+                )
+                MainTab.NOTES -> NotesScreen(
+                    uiState = notesUiState,
+                    onShowCreate = notesViewModel::onShowCreate,
+                    onDismissCreate = notesViewModel::onDismissCreate,
+                    onTitleChange = notesViewModel::onTitleChange,
+                    onContentChange = notesViewModel::onContentChange,
+                    onTagChange = notesViewModel::onTagChange,
+                    onCreateNote = notesViewModel::onCreateNote,
+                    onShowDetail = notesViewModel::onShowDetail,
+                    onDeleteNote = notesViewModel::onDeleteNote,
+                    onBackToList = notesViewModel::onBackToList
+                )
+                MainTab.MINE -> MineScreen()
+            }
+        }
+
+        // Bottom tab bar
+        CalenderlyTabBar(
+            selectedTab = appState.selectedTab,
+            onTabSelected = appViewModel::onTabSelected,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+}
+
+@Composable
+private fun CalenderlyTabBar(
+    selectedTab: MainTab,
+    onTabSelected: (MainTab) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val tabs = listOf(
+        TabItem(MainTab.CALENDAR, "Calendar", Icons.Filled.CalendarMonth),
+        TabItem(MainTab.TASKS, "Tasks", Icons.Filled.CheckCircle),
+        TabItem(MainTab.NOTES, "Notes", Icons.Filled.NoteAlt),
+        TabItem(MainTab.MINE, "Mine", Icons.Filled.Person)
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(Brush.verticalGradient(listOf(CHair, CHair)))
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(83.dp)
+                .background(Brush.verticalGradient(listOf(Color.White, Color(0xFFFDFDFF))))
+                .navigationBarsPadding()
+                .padding(top = 8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            tabs.forEach { tab ->
+                val isSelected = selectedTab == tab.id
+                val iconColor = if (isSelected) CBlue else CMuted
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable { onTabSelected(tab.id) }
+                        .padding(top = 6.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = tab.label,
+                        tint = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Text(
+                        text = tab.label,
+                        fontSize = 10.sp,
+                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                        color = iconColor
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class TabItem(val id: MainTab, val label: String, val icon: ImageVector)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/mine/MineScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/mine/MineScreen.kt
@@ -1,0 +1,398 @@
+package com.example.testingapplictionandriod.ui.mine
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Help
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.ui.components.CalenderlyButton
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CBlueBg = Color(0xFFD8EAF9)
+private val CDanger = Color(0xFFDE3030)
+private val CDangerBg = Color(0xFFFBDADA)
+private val CInk = Color(0xFF1A1A2E)
+private val CInk2 = Color(0xFF2E2E48)
+private val CMuted = Color(0xFF8B8BA7)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+private val CWarn = Color(0xFFF97316)
+private val CWarnBg = Color(0xFFFFF7ED)
+private val CWarnInk = Color(0xFF8C6E1A)
+
+@Composable
+fun MineScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(CSurface, Color.White)))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Mine",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk,
+                    letterSpacing = (-0.3).sp
+                )
+                Spacer(Modifier.weight(1f))
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(imageVector = Icons.Filled.Settings, contentDescription = "Settings", tint = CInk)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            // Profile card
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(80.dp)
+                        .background(
+                            Brush.linearGradient(listOf(CBlue, CBlueDark)),
+                            CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "HN",
+                        color = Color.White,
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "Hunaid Nakhuda",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "webdevai@growsolutions.in",
+                    fontSize = 13.sp,
+                    color = CMuted
+                )
+                Spacer(Modifier.height(12.dp))
+                Box(
+                    modifier = Modifier
+                        .background(Brush.linearGradient(listOf(CBlueBg, CBlueBg)), RoundedCornerShape(8.dp))
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    Text(text = "Free Plan", fontSize = 12.sp, fontWeight = FontWeight.Bold, color = CBlue)
+                }
+            }
+
+            // PRO upgrade card
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .background(
+                        Brush.linearGradient(listOf(CBlue, CBlueDark)),
+                        RoundedCornerShape(16.dp)
+                    )
+                    .padding(20.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = "PRO icon",
+                                tint = Color.White,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Text(
+                                text = "Upgrade to PRO",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White
+                            )
+                        }
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            text = "Remove ads · Unlimited events · Dark mode",
+                            fontSize = 12.sp,
+                            color = Color.White.copy(alpha = 0.87f)
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .background(
+                                Brush.linearGradient(listOf(Color.White.copy(alpha = 0.87f), Color.White.copy(alpha = 0.87f))),
+                                RoundedCornerShape(10.dp)
+                            )
+                            .padding(horizontal = 14.dp, vertical = 8.dp)
+                    ) {
+                        Text(text = "View", color = CBlue, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Account section
+            SettingsSection(title = "ACCOUNT") {
+                SettingsRow(
+                    icon = Icons.Filled.Edit,
+                    iconBg = CBlueBg,
+                    iconTint = CBlue,
+                    label = "Edit Profile"
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Filled.Notifications,
+                    iconBg = Color(0xFFFFF7ED),
+                    iconTint = CWarn,
+                    label = "Notifications"
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Filled.Refresh,
+                    iconBg = Color(0xFFE8F5E9),
+                    iconTint = Color(0xFF22C55E),
+                    label = "Sync Calendar"
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Preferences section
+            SettingsSection(title = "PREFERENCES") {
+                SettingsRow(
+                    icon = Icons.Filled.DarkMode,
+                    iconBg = Color(0xFFEDE7F6),
+                    iconTint = Color(0xFF7C3AED),
+                    label = "Appearance"
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Filled.GridView,
+                    iconBg = CBlueBg,
+                    iconTint = CBlue,
+                    label = "Default View"
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Filled.Lock,
+                    iconBg = Color(0xFFF3F4F6),
+                    iconTint = CMuted,
+                    label = "Privacy"
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Support section
+            SettingsSection(title = "SUPPORT") {
+                SettingsRow(
+                    icon = Icons.Filled.Help,
+                    iconBg = Color(0xFFFFF7ED),
+                    iconTint = CWarn,
+                    label = "Help & FAQ"
+                )
+                SettingsDivider()
+                SettingsRow(
+                    icon = Icons.Filled.Info,
+                    iconBg = CBlueBg,
+                    iconTint = CBlue,
+                    label = "About Calenderly"
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Danger section
+            SettingsSection(title = "") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { }
+                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(CDangerBg, RoundedCornerShape(12.dp)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Delete account",
+                            tint = CDanger,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = "Delete account", fontSize = 14.sp, fontWeight = FontWeight.SemiBold, color = CDanger)
+                        Text(text = "This action can't be undone", fontSize = 12.sp, color = CMuted)
+                    }
+                    Icon(
+                        imageVector = Icons.Filled.ChevronRight,
+                        contentDescription = null,
+                        tint = CMuted,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(100.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingsSection(title: String, content: @Composable () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        if (title.isNotBlank()) {
+            Text(
+                text = title,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                color = CMuted,
+                letterSpacing = 0.5.sp,
+                modifier = Modifier.padding(bottom = 8.dp, start = 4.dp)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Brush.verticalGradient(listOf(Color.White, CSurface)), RoundedCornerShape(16.dp))
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .padding(start = 68.dp)
+            .background(Brush.verticalGradient(listOf(CHair, CHair)))
+    )
+}
+
+@Composable
+private fun SettingsRow(
+    icon: ImageVector,
+    iconBg: Color,
+    iconTint: Color,
+    label: String,
+    trailing: @Composable () -> Unit = {
+        Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = CMuted,
+            modifier = Modifier.size(16.dp)
+        )
+    }
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .background(iconBg, RoundedCornerShape(12.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(imageVector = icon, contentDescription = label, tint = iconTint, modifier = Modifier.size(18.dp))
+        }
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            color = CInk,
+            modifier = Modifier.weight(1f)
+        )
+        trailing()
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesScreen.kt
@@ -1,0 +1,551 @@
+package com.example.testingapplictionandriod.ui.notes
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.NoteAlt
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.domain.model.Note
+import com.example.testingapplictionandriod.ui.components.CalenderlyFab
+import com.example.testingapplictionandriod.ui.components.UpgradeBanner
+import java.util.Locale
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CBlueBgSoft = Color(0xFFEEF5FF)
+private val CDanger = Color(0xFFDE3030)
+private val CDangerBg = Color(0xFFFBDADA)
+private val CInk = Color(0xFF1A1A2E)
+private val CInk3 = Color(0xFF3D3D5C)
+private val CMuted = Color(0xFF8B8BA7)
+private val CMuted2 = Color(0xFFC8C8D8)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+private val CCoralBg = Color(0xFFFFF0EE)
+
+private val NOTE_COLORS = listOf(
+    CBlueBgSoft, CCoralBg, Color(0xFFFFF7ED), CSurface, Color(0xFFE8F5E9), Color(0xFFF3E5F5)
+)
+private val MONTH_SHORT = listOf("JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")
+
+@Composable
+fun NotesScreen(
+    uiState: NotesUiState,
+    onShowCreate: () -> Unit,
+    onDismissCreate: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onContentChange: (String) -> Unit,
+    onTagChange: (String) -> Unit,
+    onCreateNote: () -> Unit,
+    onShowDetail: (String) -> Unit,
+    onDeleteNote: (String) -> Unit,
+    onBackToList: () -> Unit
+) {
+    when (uiState.currentScreen) {
+        is NotesNavScreen.List -> NotesListScreen(
+            uiState = uiState,
+            onShowCreate = onShowCreate,
+            onShowDetail = onShowDetail
+        )
+        is NotesNavScreen.Create -> NoteCreateScreen(
+            uiState = uiState,
+            onBack = onDismissCreate,
+            onTitleChange = onTitleChange,
+            onContentChange = onContentChange,
+            onTagChange = onTagChange,
+            onSave = onCreateNote
+        )
+        is NotesNavScreen.Detail -> {
+            val noteId = (uiState.currentScreen as NotesNavScreen.Detail).noteId
+            val note = uiState.notes.find { it.id == noteId }
+            if (note != null) {
+                NoteDetailScreen(
+                    note = note,
+                    onBack = onBackToList,
+                    onDelete = { onDeleteNote(noteId) }
+                )
+            } else {
+                onBackToList()
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotesListScreen(
+    uiState: NotesUiState,
+    onShowCreate: () -> Unit,
+    onShowDetail: (String) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Top bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Notes",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk,
+                    modifier = Modifier.weight(1f),
+                    letterSpacing = (-0.3).sp
+                )
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(imageVector = Icons.Filled.Search, contentDescription = "Search notes", tint = CInk)
+                }
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(imageVector = Icons.Filled.GridView, contentDescription = "Toggle grid view", tint = CInk)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+            // Search bar
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(CSurface, RoundedCornerShape(10.dp))
+                        .padding(horizontal = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(imageVector = Icons.Filled.Search, contentDescription = null, tint = CMuted, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(text = "Search notes…", fontSize = 13.sp, color = CMuted)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            if (uiState.notes.isEmpty()) {
+                NotesEmptyState()
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(uiState.notes) { note ->
+                        NoteCard(note = note, onTap = { onShowDetail(note.id) })
+                    }
+                    item { Spacer(Modifier.height(120.dp)) }
+                    item { Spacer(Modifier.height(120.dp)) }
+                }
+            }
+
+            UpgradeBanner()
+        }
+
+        CalenderlyFab(
+            onClick = onShowCreate,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 20.dp, bottom = 144.dp)
+        )
+    }
+}
+
+@Composable
+private fun NoteCard(note: Note, onTap: () -> Unit) {
+    val bgColor = NOTE_COLORS.getOrElse(note.colorIndex) { CSurface }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bgColor, RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(onClick = onTap)
+            .padding(14.dp)
+    ) {
+        if (note.tag.isNotBlank()) {
+            Box(
+                modifier = Modifier
+                    .background(
+                        Brush.linearGradient(listOf(Color.White.copy(alpha = 0.87f), Color.White.copy(alpha = 0.87f))),
+                        RoundedCornerShape(4.dp)
+                    )
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = note.tag.uppercase(Locale.getDefault()),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CMuted,
+                    letterSpacing = 0.3.sp
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+        Text(
+            text = note.title,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            color = CInk,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        if (note.content.isNotBlank()) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = note.content,
+                fontSize = 12.sp,
+                color = CInk3,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                lineHeight = 16.sp
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        val dateStr = "${MONTH_SHORT.getOrElse(note.createdMonth - 1) { "" }} ${note.createdDay}"
+        Text(text = dateStr, fontSize = 10.sp, fontWeight = FontWeight.SemiBold, color = CMuted, letterSpacing = 0.2.sp)
+    }
+}
+
+@Composable
+private fun NotesEmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 80.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(96.dp)
+                .background(
+                    Brush.linearGradient(listOf(CBlueBgSoft, CCoralBg)),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.NoteAlt,
+                contentDescription = "No notes",
+                tint = CBlue,
+                modifier = Modifier.size(40.dp)
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = "Your notes live here",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = CInk
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "Capture ideas, meeting minutes and quick thoughts. Tap + to start.",
+            fontSize = 14.sp,
+            color = CMuted,
+            lineHeight = 20.sp
+        )
+    }
+}
+
+@Composable
+private fun NoteCreateScreen(
+    uiState: NotesUiState,
+    onBack: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onContentChange: (String) -> Unit,
+    onTagChange: (String) -> Unit,
+    onSave: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onBack),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Go back",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Text(
+                    text = "New Note",
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = CInk,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(Brush.linearGradient(listOf(CBlue, CBlueDark)))
+                        .clickable(
+                            enabled = uiState.newNoteTitle.isNotBlank(),
+                            onClick = onSave
+                        )
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Text(text = "Save", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // Title
+                BasicTextField(
+                    value = uiState.newNoteTitle,
+                    onValueChange = onTitleChange,
+                    textStyle = TextStyle(
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CInk
+                    ),
+                    cursorBrush = SolidColor(CBlue),
+                    modifier = Modifier.fillMaxWidth(),
+                    decorationBox = { inner ->
+                        if (uiState.newNoteTitle.isEmpty()) {
+                            Text(text = "Note title…", color = CMuted2, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+                        }
+                        inner()
+                    }
+                )
+                // Tag
+                BasicTextField(
+                    value = uiState.newNoteTag,
+                    onValueChange = onTagChange,
+                    textStyle = TextStyle(
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = CBlue
+                    ),
+                    cursorBrush = SolidColor(CBlue),
+                    modifier = Modifier.fillMaxWidth(),
+                    decorationBox = { inner ->
+                        if (uiState.newNoteTag.isEmpty()) {
+                            Text(text = "Add tag…", color = CMuted2, fontSize = 13.sp)
+                        }
+                        inner()
+                    }
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Brush.verticalGradient(listOf(CHair, CHair)))
+                )
+                // Content
+                BasicTextField(
+                    value = uiState.newNoteContent,
+                    onValueChange = onContentChange,
+                    textStyle = TextStyle(
+                        fontSize = 15.sp,
+                        color = CInk,
+                        lineHeight = 22.sp
+                    ),
+                    cursorBrush = SolidColor(CBlue),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    decorationBox = { inner ->
+                        if (uiState.newNoteContent.isEmpty()) {
+                            Text(text = "Start writing…", color = CMuted2, fontSize = 15.sp)
+                        }
+                        inner()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NoteDetailScreen(
+    note: Note,
+    onBack: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val bgColor = NOTE_COLORS.getOrElse(note.colorIndex) { CSurface }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(bgColor, Color.White)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(bgColor, bgColor)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onBack),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Go back",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onDelete),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Save,
+                        contentDescription = "Delete note",
+                        tint = CDanger,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(horizontal = 16.dp, vertical = 16.dp)
+            ) {
+                if (note.tag.isNotBlank()) {
+                    Text(
+                        text = note.tag.uppercase(Locale.getDefault()),
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CBlue,
+                        letterSpacing = 0.3.sp
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+                Text(
+                    text = note.title,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk
+                )
+                Spacer(Modifier.height(8.dp))
+                val dateStr = "${MONTH_SHORT.getOrElse(note.createdMonth - 1) { "" }} ${note.createdDay}, ${note.createdYear}"
+                Text(text = dateStr, fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = CMuted, letterSpacing = 0.3.sp)
+                Spacer(Modifier.height(16.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Brush.verticalGradient(listOf(CHair, CHair)))
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = note.content.ifBlank { "No content" },
+                    fontSize = 15.sp,
+                    color = CInk,
+                    lineHeight = 22.sp
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesUiState.kt
@@ -1,0 +1,20 @@
+package com.example.testingapplictionandriod.ui.notes
+
+import com.example.testingapplictionandriod.domain.model.Note
+
+sealed interface NotesNavScreen {
+    data object List : NotesNavScreen
+    data object Create : NotesNavScreen
+    data class Detail(val noteId: String) : NotesNavScreen
+}
+
+data class NotesUiState(
+    val notes: List<Note> = emptyList(),
+    val currentScreen: NotesNavScreen = NotesNavScreen.List,
+    val newNoteTitle: String = "",
+    val newNoteContent: String = "",
+    val newNoteTag: String = "",
+    val selectedNoteId: String? = null,
+    val searchQuery: String = "",
+    val isSearching: Boolean = false
+)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/notes/NotesViewModel.kt
@@ -1,0 +1,92 @@
+package com.example.testingapplictionandriod.ui.notes
+
+import androidx.lifecycle.ViewModel
+import com.example.testingapplictionandriod.domain.model.Note
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.Calendar
+
+class NotesViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(NotesUiState())
+    val uiState: StateFlow<NotesUiState> = _uiState.asStateFlow()
+
+    fun onShowCreate() {
+        _uiState.update {
+            it.copy(
+                currentScreen = NotesNavScreen.Create,
+                newNoteTitle = "",
+                newNoteContent = "",
+                newNoteTag = ""
+            )
+        }
+    }
+
+    fun onDismissCreate() {
+        _uiState.update { it.copy(currentScreen = NotesNavScreen.List) }
+    }
+
+    fun onShowDetail(noteId: String) {
+        _uiState.update { it.copy(currentScreen = NotesNavScreen.Detail(noteId), selectedNoteId = noteId) }
+    }
+
+    fun onBackToList() {
+        _uiState.update { it.copy(currentScreen = NotesNavScreen.List, selectedNoteId = null) }
+    }
+
+    fun onTitleChange(title: String) {
+        _uiState.update { it.copy(newNoteTitle = title) }
+    }
+
+    fun onContentChange(content: String) {
+        _uiState.update { it.copy(newNoteContent = content) }
+    }
+
+    fun onTagChange(tag: String) {
+        _uiState.update { it.copy(newNoteTag = tag) }
+    }
+
+    fun onCreateNote() {
+        val state = _uiState.value
+        if (state.newNoteTitle.isBlank()) return
+        val today = Calendar.getInstance()
+        val note = Note(
+            title = state.newNoteTitle.trim(),
+            content = state.newNoteContent.trim(),
+            tag = state.newNoteTag.trim(),
+            colorIndex = state.notes.size % 6,
+            createdYear = today.get(Calendar.YEAR),
+            createdMonth = today.get(Calendar.MONTH) + 1,
+            createdDay = today.get(Calendar.DAY_OF_MONTH)
+        )
+        _uiState.update {
+            it.copy(
+                notes = it.notes + note,
+                currentScreen = NotesNavScreen.List,
+                newNoteTitle = "",
+                newNoteContent = "",
+                newNoteTag = ""
+            )
+        }
+    }
+
+    fun onDeleteNote(noteId: String) {
+        _uiState.update { state ->
+            state.copy(
+                notes = state.notes.filter { it.id != noteId },
+                currentScreen = NotesNavScreen.List,
+                selectedNoteId = null
+            )
+        }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _uiState.update { it.copy(searchQuery = query) }
+    }
+
+    fun onToggleSearch() {
+        _uiState.update { it.copy(isSearching = !it.isSearching, searchQuery = "") }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/onboarding/OnboardingScreen.kt
@@ -1,0 +1,208 @@
+package com.example.testingapplictionandriod.ui.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.ui.components.CalenderlyButton
+
+private val PrimaryBlue = Color(0xFF2564CF)
+private val PrimaryBlueDark = Color(0xFF1A3A80)
+private val PrimaryBlueBg = Color(0xFFD8EAF9)
+private val PrimaryBlueBgSoft = Color(0xFFEEF5FF)
+private val InkColor = Color(0xFF1A1A2E)
+private val MutedColor = Color(0xFF8B8BA7)
+private val HairColor = Color(0xFFE4E4ED)
+private val CoralColor = Color(0xFFE85C4A)
+private val CoralBgColor = Color(0xFFFFF0EE)
+private val SurfaceColor = Color(0xFFF7F7FB)
+
+@Composable
+fun OnboardingScreen(
+    step: Int,
+    onNext: () -> Unit,
+    onGetStarted: () -> Unit
+) {
+    val isLastStep = step == 1
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, SurfaceColor)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Hero illustration area
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(360.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                if (isLastStep) CoralBgColor else PrimaryBlueBg,
+                                Color.White
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isLastStep) {
+                    OnboardingIllustration2()
+                } else {
+                    OnboardingIllustration1()
+                }
+            }
+
+            // Content area
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Spacer(Modifier.height(20.dp))
+
+                // Step dots
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    repeat(2) { i ->
+                        Box(
+                            modifier = Modifier
+                                .size(if (i == step) 20.dp else 8.dp, 8.dp)
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(if (i == step) PrimaryBlue else HairColor)
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(20.dp))
+
+                Text(
+                    text = if (isLastStep) "Go PRO, go further" else "Never miss a day",
+                    fontSize = 26.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = InkColor,
+                    textAlign = TextAlign.Center,
+                    letterSpacing = (-0.3).sp
+                )
+
+                Spacer(Modifier.height(12.dp))
+
+                Text(
+                    text = if (isLastStep) {
+                        "Unlock unlimited events, remove ads, and enjoy beautiful themes."
+                    } else {
+                        "See all your events, tasks and notes in one beautifully organized calendar."
+                    },
+                    fontSize = 14.sp,
+                    color = MutedColor,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 20.sp
+                )
+
+                Spacer(Modifier.height(32.dp))
+
+                CalenderlyButton(
+                    label = if (isLastStep) "Get Started" else "Next",
+                    onClick = if (isLastStep) onGetStarted else onNext
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnboardingIllustration1() {
+    Box(
+        modifier = Modifier.size(220.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        // Main calendar card
+        Box(
+            modifier = Modifier
+                .size(160.dp, 140.dp)
+                .align(Alignment.CenterStart)
+                .padding(start = 30.dp, top = 40.dp)
+                .background(Brush.verticalGradient(listOf(Color.White, Color(0xFFFAFAFC))), RoundedCornerShape(18.dp))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(34.dp)
+                    .background(
+                        Brush.linearGradient(listOf(PrimaryBlue, PrimaryBlueDark)),
+                        RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp)
+                    ),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Box(Modifier.size(6.dp).background(Brush.linearGradient(listOf(Color.White, Color.White)), CircleShape))
+                    Box(Modifier.size(6.dp).background(Brush.linearGradient(listOf(Color.White.copy(alpha = 0.87f), Color.White.copy(alpha = 0.87f))), CircleShape))
+                }
+            }
+        }
+        // Calendar icon overlay
+        Icon(
+            imageVector = Icons.Filled.CalendarMonth,
+            contentDescription = "Calendar illustration",
+            tint = PrimaryBlue,
+            modifier = Modifier.size(56.dp).align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun OnboardingIllustration2() {
+    Box(
+        modifier = Modifier.size(220.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .background(
+                    Brush.linearGradient(
+                        listOf(CoralColor, Color(0xFFF97316))
+                    ),
+                    RoundedCornerShape(30.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Star,
+                contentDescription = "PRO star illustration",
+                tint = Color.White,
+                modifier = Modifier.size(56.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/splash/SplashScreen.kt
@@ -1,0 +1,93 @@
+package com.example.testingapplictionandriod.ui.splash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+
+private val SplashBgStart = Color(0xFFE8F0FA)
+private val SplashBgEnd = Color(0xFFFFFFFF)
+private val PrimaryBlue = Color(0xFF2564CF)
+private val PrimaryBlueDark = Color(0xFF1A3A80)
+private val InkColor = Color(0xFF1A1A2E)
+private val MutedColor = Color(0xFF8B8BA7)
+
+@Composable
+fun SplashScreen(onSplashDone: () -> Unit) {
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        delay(1500)
+        onSplashDone()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(SplashBgStart, SplashBgEnd))),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .background(
+                        Brush.linearGradient(listOf(PrimaryBlue, PrimaryBlueDark)),
+                        RoundedCornerShape(28.dp)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.CalendarMonth,
+                    contentDescription = "Calenderly app icon",
+                    tint = Color.White,
+                    modifier = Modifier.size(44.dp)
+                )
+            }
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = "Calenderly",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                color = InkColor,
+                letterSpacing = (-0.5).sp
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "Your time, beautifully organized.",
+                fontSize = 13.sp,
+                color = MutedColor
+            )
+        }
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Spacer(Modifier.height(40.dp))
+            Text(
+                text = "v1.0.0",
+                fontSize = 11.sp,
+                color = Color(0xFFC8C8D8),
+                modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksScreen.kt
@@ -1,0 +1,725 @@
+package com.example.testingapplictionandriod.ui.tasks
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.testingapplictionandriod.domain.model.Task
+import com.example.testingapplictionandriod.domain.model.TaskPriority
+import com.example.testingapplictionandriod.ui.components.CalenderlyButton
+import com.example.testingapplictionandriod.ui.components.CalenderlyFab
+import com.example.testingapplictionandriod.ui.components.UpgradeBanner
+
+private val CBlue = Color(0xFF2564CF)
+private val CBlueDark = Color(0xFF1A3A80)
+private val CBlueBgSoft = Color(0xFFEEF5FF)
+private val CDanger = Color(0xFFDE3030)
+private val CDangerBg = Color(0xFFFBDADA)
+private val CDangerInk = Color(0xFF801515)
+private val CSuccess = Color(0xFF22C55E)
+private val CWarn = Color(0xFFF97316)
+private val CWarnBg = Color(0xFFFFF7ED)
+private val CWarnInk = Color(0xFF8C6E1A)
+private val CInk = Color(0xFF1A1A2E)
+private val CMuted = Color(0xFF8B8BA7)
+private val CMuted2 = Color(0xFFC8C8D8)
+private val CHair = Color(0xFFE4E4ED)
+private val CSurface = Color(0xFFF7F7FB)
+
+@Composable
+fun TasksScreen(
+    uiState: TasksUiState,
+    onShowCreate: () -> Unit,
+    onDismissCreate: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onNotesChange: (String) -> Unit,
+    onPriorityChange: (TaskPriority) -> Unit,
+    onCreateTask: () -> Unit,
+    onToggleComplete: (String) -> Unit,
+    onShowDetail: (String) -> Unit,
+    onDeleteTask: (String) -> Unit,
+    onBackToList: () -> Unit
+) {
+    when (uiState.currentScreen) {
+        is TasksNavScreen.List -> TasksListScreen(
+            uiState = uiState,
+            onShowCreate = onShowCreate,
+            onToggleComplete = onToggleComplete,
+            onShowDetail = onShowDetail
+        )
+        is TasksNavScreen.Create -> TasksListScreen(
+            uiState = uiState,
+            onShowCreate = onShowCreate,
+            onToggleComplete = onToggleComplete,
+            onShowDetail = onShowDetail,
+            showCreateSheet = true,
+            onDismissCreate = onDismissCreate,
+            onTitleChange = onTitleChange,
+            onNotesChange = onNotesChange,
+            onPriorityChange = onPriorityChange,
+            onCreateTask = onCreateTask
+        )
+        is TasksNavScreen.Detail -> {
+            val taskId = (uiState.currentScreen as TasksNavScreen.Detail).taskId
+            val task = uiState.tasks.find { it.id == taskId }
+            if (task != null) {
+                TaskDetailSheet(
+                    task = task,
+                    onDismiss = onBackToList,
+                    onToggleComplete = { onToggleComplete(taskId) },
+                    onDelete = { onDeleteTask(taskId) }
+                )
+            } else {
+                onBackToList()
+            }
+        }
+    }
+}
+
+@Composable
+private fun TasksListScreen(
+    uiState: TasksUiState,
+    onShowCreate: () -> Unit,
+    onToggleComplete: (String) -> Unit,
+    onShowDetail: (String) -> Unit,
+    showCreateSheet: Boolean = false,
+    onDismissCreate: () -> Unit = {},
+    onTitleChange: (String) -> Unit = {},
+    onNotesChange: (String) -> Unit = {},
+    onPriorityChange: (TaskPriority) -> Unit = {},
+    onCreateTask: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Top bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Tasks",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk,
+                    modifier = Modifier.weight(1f),
+                    letterSpacing = (-0.3).sp
+                )
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(imageVector = Icons.Filled.Search, contentDescription = "Search tasks", tint = CInk)
+                }
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(imageVector = Icons.Filled.MoreVert, contentDescription = "More options", tint = CInk)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            if (uiState.tasks.isEmpty()) {
+                TasksEmptyState()
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    val today = uiState.tasks.filter { !it.isCompleted }
+                    val completed = uiState.tasks.filter { it.isCompleted }
+
+                    if (today.isNotEmpty()) {
+                        item {
+                            TaskSectionHeader(label = "TODAY", count = today.size)
+                        }
+                        items(today) { task ->
+                            TaskRow(
+                                task = task,
+                                onToggle = { onToggleComplete(task.id) },
+                                onTap = { onShowDetail(task.id) }
+                            )
+                        }
+                    }
+                    if (completed.isNotEmpty()) {
+                        item {
+                            TaskSectionHeader(label = "COMPLETED", count = completed.size)
+                        }
+                        items(completed) { task ->
+                            TaskRow(
+                                task = task,
+                                onToggle = { onToggleComplete(task.id) },
+                                onTap = { onShowDetail(task.id) }
+                            )
+                        }
+                    }
+                    item { Spacer(Modifier.height(200.dp)) }
+                }
+            }
+
+            UpgradeBanner()
+        }
+
+        CalenderlyFab(
+            onClick = onShowCreate,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 20.dp, bottom = 144.dp)
+        )
+
+        if (showCreateSheet) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Brush.verticalGradient(listOf(Color(0x731A1A2E), Color(0x731A1A2E))))
+                    .clickable(onClick = onDismissCreate)
+            )
+            CreateTaskSheet(
+                uiState = uiState,
+                onDismiss = onDismissCreate,
+                onTitleChange = onTitleChange,
+                onNotesChange = onNotesChange,
+                onPriorityChange = onPriorityChange,
+                onCreate = onCreateTask,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
+    }
+}
+
+@Composable
+private fun TaskSectionHeader(label: String, count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(40.dp)
+            .background(Brush.verticalGradient(listOf(CSurface, CSurface)))
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = label,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.5.sp
+        )
+        Box(
+            modifier = Modifier
+                .background(Brush.linearGradient(listOf(Color.White, Color.White)), RoundedCornerShape(8.dp))
+                .padding(horizontal = 6.dp, vertical = 1.dp)
+        ) {
+            Text(text = count.toString(), fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = CMuted2)
+        }
+    }
+}
+
+@Composable
+private fun TaskRow(
+    task: Task,
+    onToggle: () -> Unit,
+    onTap: () -> Unit
+) {
+    val isOverdue = !task.isCompleted && task.priority == TaskPriority.HIGH
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+            .clickable(onClick = onTap)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onToggle),
+            contentAlignment = Alignment.Center
+        ) {
+            if (task.isCompleted) {
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = "Mark as incomplete",
+                    tint = CSuccess,
+                    modifier = Modifier.size(22.dp)
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.RadioButtonUnchecked,
+                    contentDescription = "Mark as complete",
+                    tint = if (isOverdue) CDanger else CMuted2,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = task.title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = if (task.isCompleted) CMuted2 else CInk,
+                textDecoration = if (task.isCompleted) TextDecoration.LineThrough else null
+            )
+            if (!task.isCompleted) {
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (task.priority != TaskPriority.NONE) {
+                        val (bg, ink) = when (task.priority) {
+                            TaskPriority.HIGH -> CDangerBg to CDangerInk
+                            TaskPriority.MEDIUM -> CWarnBg to CWarnInk
+                            else -> CSurface to CMuted
+                        }
+                        Box(
+                            modifier = Modifier
+                                .background(bg, RoundedCornerShape(6.dp))
+                                .padding(horizontal = 8.dp, vertical = 2.dp)
+                        ) {
+                            Text(
+                                text = task.priority.name,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = ink
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Icon(imageVector = Icons.Filled.MoreVert, contentDescription = "More options", tint = CMuted2)
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .padding(start = 52.dp)
+            .background(Brush.verticalGradient(listOf(CHair, CHair)))
+    )
+}
+
+@Composable
+private fun TasksEmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp)
+            .padding(top = 80.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .size(96.dp)
+                .background(
+                    Brush.linearGradient(listOf(CBlueBgSoft, CSurface)),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = "No tasks",
+                tint = CBlue,
+                modifier = Modifier.size(40.dp)
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = "All clear!",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = CInk
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "You don't have any tasks yet. Tap the + button to add your first one.",
+            fontSize = 14.sp,
+            color = CMuted,
+            lineHeight = 20.sp
+        )
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun CreateTaskSheet(
+    uiState: TasksUiState,
+    onDismiss: () -> Unit,
+    onTitleChange: (String) -> Unit,
+    onNotesChange: (String) -> Unit,
+    onPriorityChange: (TaskPriority) -> Unit,
+    onCreate: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(listOf(Color.White, CSurface)),
+                RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+            )
+            .padding(horizontal = 20.dp)
+    ) {
+        Spacer(Modifier.height(12.dp))
+        Box(
+            modifier = Modifier
+                .width(36.dp)
+                .height(4.dp)
+                .background(Brush.linearGradient(listOf(CHair, CHair)), RoundedCornerShape(2.dp))
+                .align(Alignment.CenterHorizontally)
+        )
+        Spacer(Modifier.height(20.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "New Task",
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+                color = CInk,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(Brush.verticalGradient(listOf(CHair, CHair)))
+        )
+        Spacer(Modifier.height(16.dp))
+
+        // Title input
+        Text(
+            text = "TASK",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.3.sp
+        )
+        Spacer(Modifier.height(6.dp))
+        BasicTextField(
+            value = uiState.newTaskTitle,
+            onValueChange = onTitleChange,
+            textStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold, color = CInk),
+            cursorBrush = SolidColor(CBlue),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(listOf(Color.White, Color.White)),
+                    RoundedCornerShape(12.dp)
+                )
+                .padding(14.dp),
+            decorationBox = { inner ->
+                if (uiState.newTaskTitle.isEmpty()) {
+                    Text(text = "What needs to be done?", color = CMuted2, fontSize = 16.sp)
+                }
+                inner()
+            }
+        )
+        Spacer(Modifier.height(14.dp))
+
+        // Priority selector
+        Text(
+            text = "PRIORITY",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.3.sp
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            listOf(
+                Triple(TaskPriority.LOW, CSurface, CMuted),
+                Triple(TaskPriority.MEDIUM, CWarnBg, CWarnInk),
+                Triple(TaskPriority.HIGH, CDangerBg, CDangerInk)
+            ).forEach { (priority, bg, textColor) ->
+                val isSelected = uiState.newTaskPriority == priority
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(40.dp)
+                        .background(
+                            if (isSelected) Brush.linearGradient(listOf(bg, bg))
+                            else Brush.linearGradient(listOf(Color.White, Color.White)),
+                            RoundedCornerShape(12.dp)
+                        )
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable { onPriorityChange(priority) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = priority.name,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = if (isSelected) textColor else CMuted
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(14.dp))
+
+        // Notes
+        Text(
+            text = "NOTES",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = CMuted,
+            letterSpacing = 0.3.sp
+        )
+        Spacer(Modifier.height(6.dp))
+        BasicTextField(
+            value = uiState.newTaskNotes,
+            onValueChange = onNotesChange,
+            textStyle = TextStyle(fontSize = 13.sp, color = CInk),
+            cursorBrush = SolidColor(CBlue),
+            minLines = 3,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(listOf(Color.White, Color.White)),
+                    RoundedCornerShape(12.dp)
+                )
+                .padding(14.dp),
+            decorationBox = { inner ->
+                if (uiState.newTaskNotes.isEmpty()) {
+                    Text(text = "Add details…", color = CMuted2, fontSize = 13.sp)
+                }
+                inner()
+            }
+        )
+        Spacer(Modifier.height(20.dp))
+        CalenderlyButton(
+            label = "Create Task",
+            onClick = onCreate,
+            enabled = uiState.newTaskTitle.isNotBlank()
+        )
+        Spacer(Modifier.height(32.dp))
+    }
+}
+
+@Composable
+private fun TaskDetailSheet(
+    task: Task,
+    onDismiss: () -> Unit,
+    onToggleComplete: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brush.verticalGradient(listOf(Color.White, CSurface)))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Back header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Brush.verticalGradient(listOf(Color.White, Color.White)))
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onDismiss),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.RadioButtonUnchecked,
+                        contentDescription = "Back to tasks",
+                        tint = CInk,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Text(
+                    text = "Task Detail",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = CInk,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 8.dp)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Brush.verticalGradient(listOf(CHair, CHair)))
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 20.dp)
+            ) {
+                Row(verticalAlignment = Alignment.Top) {
+                    Box(
+                        modifier = Modifier
+                            .size(26.dp)
+                            .background(
+                                Brush.linearGradient(
+                                    if (task.isCompleted) listOf(CSuccess, CSuccess)
+                                    else listOf(Color.White, Color.White)
+                                ),
+                                CircleShape
+                            )
+                            .clip(CircleShape)
+                            .clickable(onClick = onToggleComplete),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (task.isCompleted) {
+                            Text(text = "✓", color = Color.White, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = task.title,
+                            fontSize = 19.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = CInk,
+                            textDecoration = if (task.isCompleted) TextDecoration.LineThrough else null
+                        )
+                        if (task.priority != TaskPriority.NONE) {
+                            Spacer(Modifier.height(8.dp))
+                            val (bg, ink) = when (task.priority) {
+                                TaskPriority.HIGH -> CDangerBg to CDangerInk
+                                TaskPriority.MEDIUM -> CWarnBg to CWarnInk
+                                else -> CSurface to CMuted
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .background(bg, RoundedCornerShape(10.dp))
+                                    .padding(horizontal = 12.dp, vertical = 6.dp)
+                            ) {
+                                Text(task.priority.name, fontSize = 12.sp, fontWeight = FontWeight.Bold, color = ink)
+                            }
+                        }
+                    }
+                }
+
+                if (task.notes.isNotBlank()) {
+                    Spacer(Modifier.height(20.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(Brush.verticalGradient(listOf(CHair, CHair)))
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = "NOTES",
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = CMuted,
+                        letterSpacing = 0.5.sp
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = task.notes,
+                        fontSize = 14.sp,
+                        color = Color(0xFF3D3D5C),
+                        lineHeight = 20.sp
+                    )
+                }
+
+                Spacer(Modifier.height(32.dp))
+
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp)
+                            .background(
+                                Brush.linearGradient(listOf(CBlueBgSoft, CBlueBgSoft)),
+                                RoundedCornerShape(12.dp)
+                            )
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable(onClick = onToggleComplete),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = if (task.isCompleted) "Undo" else "Mark Done",
+                            color = CBlue,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(44.dp)
+                            .background(
+                                Brush.linearGradient(listOf(CDangerBg, CDangerBg)),
+                                RoundedCornerShape(12.dp)
+                            )
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable(onClick = onDelete),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(text = "Delete", color = CDanger, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksUiState.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksUiState.kt
@@ -1,0 +1,19 @@
+package com.example.testingapplictionandriod.ui.tasks
+
+import com.example.testingapplictionandriod.domain.model.Task
+import com.example.testingapplictionandriod.domain.model.TaskPriority
+
+sealed interface TasksNavScreen {
+    data object List : TasksNavScreen
+    data object Create : TasksNavScreen
+    data class Detail(val taskId: String) : TasksNavScreen
+}
+
+data class TasksUiState(
+    val tasks: List<Task> = emptyList(),
+    val currentScreen: TasksNavScreen = TasksNavScreen.List,
+    val newTaskTitle: String = "",
+    val newTaskNotes: String = "",
+    val newTaskPriority: TaskPriority = TaskPriority.NONE,
+    val selectedTaskId: String? = null
+)

--- a/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/testingapplictionandriod/ui/tasks/TasksViewModel.kt
@@ -1,0 +1,89 @@
+package com.example.testingapplictionandriod.ui.tasks
+
+import androidx.lifecycle.ViewModel
+import com.example.testingapplictionandriod.domain.model.Task
+import com.example.testingapplictionandriod.domain.model.TaskPriority
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class TasksViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TasksUiState())
+    val uiState: StateFlow<TasksUiState> = _uiState.asStateFlow()
+
+    fun onShowCreate() {
+        _uiState.update {
+            it.copy(
+                currentScreen = TasksNavScreen.Create,
+                newTaskTitle = "",
+                newTaskNotes = "",
+                newTaskPriority = TaskPriority.NONE
+            )
+        }
+    }
+
+    fun onDismissCreate() {
+        _uiState.update { it.copy(currentScreen = TasksNavScreen.List) }
+    }
+
+    fun onShowDetail(taskId: String) {
+        _uiState.update { it.copy(currentScreen = TasksNavScreen.Detail(taskId), selectedTaskId = taskId) }
+    }
+
+    fun onBackToList() {
+        _uiState.update { it.copy(currentScreen = TasksNavScreen.List, selectedTaskId = null) }
+    }
+
+    fun onTitleChange(title: String) {
+        _uiState.update { it.copy(newTaskTitle = title) }
+    }
+
+    fun onNotesChange(notes: String) {
+        _uiState.update { it.copy(newTaskNotes = notes) }
+    }
+
+    fun onPriorityChange(priority: TaskPriority) {
+        _uiState.update { it.copy(newTaskPriority = priority) }
+    }
+
+    fun onCreateTask() {
+        val state = _uiState.value
+        if (state.newTaskTitle.isBlank()) return
+        val task = Task(
+            title = state.newTaskTitle.trim(),
+            notes = state.newTaskNotes.trim(),
+            priority = state.newTaskPriority
+        )
+        _uiState.update {
+            it.copy(
+                tasks = it.tasks + task,
+                currentScreen = TasksNavScreen.List,
+                newTaskTitle = "",
+                newTaskNotes = "",
+                newTaskPriority = TaskPriority.NONE
+            )
+        }
+    }
+
+    fun onToggleComplete(taskId: String) {
+        _uiState.update { state ->
+            state.copy(
+                tasks = state.tasks.map { t ->
+                    if (t.id == taskId) t.copy(isCompleted = !t.isCompleted) else t
+                }
+            )
+        }
+    }
+
+    fun onDeleteTask(taskId: String) {
+        _uiState.update { state ->
+            state.copy(
+                tasks = state.tasks.filter { it.id != taskId },
+                currentScreen = TasksNavScreen.List,
+                selectedTaskId = null
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented all 22 screens from the Calenderly Extended Screens design file
- Added Splash screen (S01) and 2-step Onboarding flow (S02–S03) with SharedPreferences first-launch detection
- Redesigned Calendar screen (S04/S05) to Calenderly style: light/white theme, primary blue `#2564CF`, clean month grid with event bars, week-day header, FAB, upgrade banner
- Added proper 4-tab bottom navigation (Calendar / Tasks / Notes / Mine)
- New **Tasks** tab (S08–S11): list with Today/Upcoming/Completed sections, create sheet, detail sheet, priority badges, toggle-complete
- New **Notes** tab (S12–S14): 2-column grid, color-coded cards by tag, create editor, detail view
- New **Mine/Profile** tab (S15–S20): avatar, PRO upgrade card, account/preferences/support settings rows
- New **Day View** (S21): scrollable timeline with hour slots and event blocks
- New **Week View** (S22): 7-column grid with today highlight and event blocks

## Changed Files

| File | Change |
|------|--------|
| `MainActivity.kt` | Routes Splash → Onboarding → Main via AppViewModel |
| `ui/app/AppUiState.kt` + `AppViewModel.kt` | New: app-level navigation state + SharedPrefs first-launch |
| `ui/splash/SplashScreen.kt` | New: gradient splash with 1.5s delay |
| `ui/onboarding/OnboardingScreen.kt` | New: 2-step onboarding with hero illustrations |
| `ui/main/MainScreen.kt` | New: 4-tab container with Calenderly tab bar |
| `ui/components/Components.kt` | New: shared `CalenderlyButton`, `CalenderlyFab`, `UpgradeBanner` |
| `ui/calendar/CalendarScreen.kt` | Redesigned to Calenderly light style |
| `ui/calendar/CalendarUiState.kt` | Added `DayView` + `WeekView` nav screens |
| `ui/calendar/CalendarViewModel.kt` | Added `onShowDayView`, `onShowWeekView`, `onToggleNotifications` |
| `ui/calendar/CreateEventScreen.kt` | Redesigned to Calenderly style |
| `ui/calendar/EventDetailScreen.kt` | Redesigned to Calenderly style |
| `ui/calendar/DayViewScreen.kt` | New: scrollable day timeline (S21) |
| `ui/calendar/WeekViewScreen.kt` | New: 7-column week grid (S22) |
| `ui/tasks/TasksScreen.kt` + ViewModel + UiState | New: Tasks tab (S08–S11) |
| `ui/notes/NotesScreen.kt` + ViewModel + UiState | New: Notes tab (S12–S14) |
| `ui/mine/MineScreen.kt` | New: Mine/Profile tab (S15–S20) |
| `domain/model/Task.kt` + `Note.kt` | New: pure Kotlin domain models |

## Testing Notes

- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL (all existing tests pass)
- `bash scripts/check-claude-md.sh` — all checks passed
- `bash scripts/check-claude-md.sh --diff origin/main` — all checks passed

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)